### PR TITLE
Fix 5/7 vulnerabilities with npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5731,9 +5731,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",


### PR DESCRIPTION
`npm install` showed me 7 errors out of which `npm audit fix` fixed 5, but the other still need attention as they might be breaking changes.

```
                                                                                
                       === npm audit security report ===                        
                                                                                
# Run  npm install dompurify@2.0.7  to resolve 2 vulnerabilities
SEMVER WARNING: Recommended action is a potentially breaking change
                                                                                
  Critical        Cross-Site Scripting                                          
                                                                                
  Package         dompurify                                                     
                                                                                
  Dependency of   dompurify                                                     
                                                                                
  Path            dompurify                                                     
                                                                                
  More info       https://npmjs.com/advisories/1205                             
                                                                                


                                                                                
  Critical        Cross-Site Scripting                                          
                                                                                
  Package         dompurify                                                     
                                                                                
  Dependency of   dompurify                                                     
                                                                                
  Path            dompurify                                                     
                                                                                
  More info       https://npmjs.com/advisories/1223                             
                                                                                


found 2 critical severity vulnerabilities in 890751 scanned packages
  2 vulnerabilities require semver-major dependency updates.
```