### PR TITLE
[config] Add hot-module-replacement to the webpack configuration

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -53,3 +53,7 @@ render(
   </CookiesProvider>,
   document.getElementById("root"),
 );
+
+if (module && module.hot) {
+  module.hot.accept();
+}

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -80,6 +80,7 @@ module.exports = (env, argv) => {
       proxy: {
         "/api": "http://localhost:3030",
       },
+      hot: true,
     },
     optimization: {
       runtimeChunk: "single",


### PR DESCRIPTION
Added hot-module-replacement support. Described in [issue#33](https://github.com/openwisp/openwisp-wifi-login-pages/issues/33)