### PR TITLE
Allow custom ports #34

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -5,9 +5,27 @@ const HtmlWebpackPlugin = require("html-webpack-plugin");
 const path = require("path");
 
 const CURRENT_WORKING_DIR = process.cwd();
+const DEFAULT_PORT = 8080;
+const DEFAULT_SERVER_URL = "http://localhost:3030";
 
 module.exports = (env, argv) => {
-  const config = {
+  // Use user-specified port; if none was given, fall back to the default
+  // If the default port is already in use, webpack will automatically use
+  // the next available port
+  let port = argv.port || DEFAULT_PORT;
+
+  // The url the server is running on; if none was given, fall back to the default
+  let serverUrl = argv.server;
+  if (serverUrl != undefined) {
+    console.log(`Expecting server to run on ${serverUrl}`);
+  } else {
+    console.warn(
+      `No server url specified. It is being assumed that the server runs on ${DEFAULT_SERVER_URL}`,
+    );
+    serverUrl = DEFAULT_SERVER_URL;
+  }
+
+  return {
     context: path.resolve(CURRENT_WORKING_DIR, "client"),
     entry: {
       main: "./index.js",
@@ -58,6 +76,7 @@ module.exports = (env, argv) => {
     ],
 
     devServer: {
+      port: argv.port,
       stats: {
         colors: true,
       },
@@ -67,7 +86,7 @@ module.exports = (env, argv) => {
         warnings: true,
         errors: true,
       },
-      disableHostCheck: true, 
+      disableHostCheck: true,
       progress: true,
       stats: "errors-only",
       open: true,
@@ -78,7 +97,7 @@ module.exports = (env, argv) => {
       },
       historyApiFallback: true,
       proxy: {
-        "/api": "http://localhost:3030",
+        "/api": serverUrl,
       },
     },
     optimization: {
@@ -109,5 +128,4 @@ module.exports = (env, argv) => {
       fs: "empty",
     },
   };
-  return config;
 };

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -12,15 +12,15 @@ module.exports = (env, argv) => {
   // Use user-specified port; if none was given, fall back to the default
   // If the default port is already in use, webpack will automatically use
   // the next available port
-  let port = argv.port || DEFAULT_PORT;
+  let clientP = process.env.CLIENT;
 
   // The url the server is running on; if none was given, fall back to the default
-  let serverUrl = argv.server;
-  if (serverUrl != undefined) {
-    console.log(`Expecting server to run on ${serverUrl}`);
+  let serverUrl;
+  if (process.env.SERVER != undefined) {
+    serverUrl = `http://localhost:${process.env.SERVER}`;
   } else {
     console.warn(
-      `No server url specified. It is being assumed that the server runs on ${DEFAULT_SERVER_URL}`,
+      `No server url specified. Expecting server to run on ${DEFAULT_SERVER_URL}`,
     );
     serverUrl = DEFAULT_SERVER_URL;
   }
@@ -76,7 +76,7 @@ module.exports = (env, argv) => {
     ],
 
     devServer: {
-      port: argv.port,
+      port: clientP,
       stats: {
         colors: true,
       },

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   },
   "scripts": {
     "build": "npm run setup && webpack --mode production --progress --config config/webpack.config.js",
-    "client": "npm run setup && webpack-dev-server --host 0.0.0.0 --port 8080 --mode development --config config/webpack.config.js",
+    "client": "npm run setup && webpack-dev-server --host 0.0.0.0 --mode development --config config/webpack.config.js",
     "coveralls": "jest --coverage && cat ./coverage/lcov.info | coveralls",
     "server": "npm run setup && nodemon server/start.js",
     "setup": "node config/setup.js",

--- a/readme.md
+++ b/readme.md
@@ -75,21 +75,25 @@ $ npm test 			# Run tests
 
 #### Using custom ports
 
-To start the server on port 5000, use the following command:
+To start the client and/or server on a port of your liking, you must set environment
+variables before starting.
 
-```
-$ npm run server -- --port=5000
-```
+To run the client on port 4000 and the server on port 5000, use the following command:
 
-The following command starts the client on port 4000 and tells it that the server
-runs on http://localhost:5000
-
-```
-$ npm run client -- --port=4000 --server=http://localhost:5000
+```bash
+$ CLIENT=4000 SERVER=5000 npm run start
 ```
 
-**Note the additional -- before the port arguments!**
-This tells npm that the arguments are not for the `npm run` command itself, but the for the scripts invoked by npm (in this case _server_ or _client_).
+You can also run the client and server commands seperately:
+
+```bash
+$ SERVER=5000 npm run server
+$ CLIENT=4000 SERVER=5000 npm run client
+```
+
+Note that you need to tell the client the server's port
+(unless you're using the default server port, which is 3030)
+so the client knows where he can find the server.
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -78,17 +78,40 @@ $ npm test 			# Run tests
 To start the client and/or server on a port of your liking, you must set environment
 variables before starting.
 
-To run the client on port 4000 and the server on port 5000, use the following command:
+**To run the client on port 4000 and the server on port 5000, use the following command:**
 
-```bash
+Bash (Linux):
+
+```
 $ CLIENT=4000 SERVER=5000 npm run start
 ```
 
-You can also run the client and server commands seperately:
+Powershell (Windows):
 
-```bash
+```
+PS> $env:CLIENT = 4000; $env:SERVER = 5000; npm run start
+```
+
+**You can also run the client and server commands separately:**
+
+Bash (Linux):
+
+```
 $ SERVER=5000 npm run server
+```
+
+```
 $ CLIENT=4000 SERVER=5000 npm run client
+```
+
+Powershell (Windows):
+
+```
+PS> $env:SERVER = 5000; npm run server
+```
+
+```
+PS> $env:CLIENT = 4000; $env:SERVER = 5000; npm run client
 ```
 
 Note that you need to tell the client the server's port

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,24 @@ $ npm run lint:fix 	 	# Run ESLint with automatically fix problems option
 $ npm test 			# Run tests
 ```
 
+#### Using custom ports
+
+To start the server on port 5000, use the following command:
+
+```
+$ npm run server -- --port=5000
+```
+
+The following command starts the client on port 4000 and tells it that the server
+runs on http://localhost:5000
+
+```
+$ npm run client -- --port=4000 --server=http://localhost:5000
+```
+
+**Note the additional -- before the port arguments!**
+This tells npm that the arguments are not for the `npm run` command itself, but the for the scripts invoked by npm (in this case _server_ or _client_).
+
 ### License
 
 See [LICENSE](https://github.com/openwisp/openwisp-wifi-login-pages/blob/master/LICENSE).

--- a/server/index.js
+++ b/server/index.js
@@ -20,7 +20,6 @@ app.get("*", function(req, res) {
 });
 
 const DEFAULT_PORT = 3030;
-const portArg = process.argv.find(arg => arg.startsWith("--port="));
 
 // Finds the next free port, starting at the passed port
 const nextFreePort = (port, callback) => {
@@ -43,10 +42,9 @@ const nextFreePort = (port, callback) => {
 };
 
 // If a port was passed as an argument, use that port
-if (portArg) {
-  const port = portArg.split("=")[1];
-  app.listen(port, () => {
-    console.log(`Server started on port ${port}`);
+if (process.env.SERVER !== undefined) {
+  app.listen(process.env.SERVER, () => {
+    console.log(`Server started on port ${process.env.SERVER}`);
   });
 } else {
   // Otherwise, find the next free port starting at the default port

--- a/server/index.js
+++ b/server/index.js
@@ -2,10 +2,10 @@ import compression from "compression";
 import cookieParser from "cookie-parser";
 import express from "express";
 import cookiesMiddleware from "universal-cookie-express";
+import path from "path";
+import net from "net";
 
 import routes from "./routes";
-
-const path = require("path");
 
 const app = express();
 app.use(compression());
@@ -18,6 +18,41 @@ app.use("/api/v1/:organization/account", routes.account);
 app.get("*", function(req, res) {
   res.sendFile(path.join(process.cwd(), "dist", "index.html"));
 });
-app.listen(3030, () => {
-  console.log("Server started on port 3030");
-});
+
+const DEFAULT_PORT = 3030;
+const portArg = process.argv.find(arg => arg.startsWith("--port="));
+
+// Finds the next free port, starting at the passed port
+const nextFreePort = (port, callback) => {
+  const server = net.createServer(socket => {
+    socket.write("Testing socket..\r\n");
+    socket.pipe(socket);
+  });
+
+  // If port is already in use, try next port
+  server.listen(port, "127.0.0.1");
+  server.on("error", () => {
+    nextFreePort(port + 1, callback);
+  });
+
+  // If port is available, pass port to callback
+  server.on("listening", () => {
+    server.close();
+    callback(port);
+  });
+};
+
+// If a port was passed as an argument, use that port
+if (portArg) {
+  const port = portArg.split("=")[1];
+  app.listen(port, () => {
+    console.log(`Server started on port ${port}`);
+  });
+} else {
+  // Otherwise, find the next free port starting at the default port
+  nextFreePort(DEFAULT_PORT, port => {
+    app.listen(port, () => {
+      console.log(`Server started on port ${port}`);
+    });
+  });
+}


### PR DESCRIPTION
Currently the webpack dev server and nodemon are running on a fixed
port.

This commit allows developers to choose their own port.
If no port was specified and the default one is already in use,
it will automatically find the next free port.

For information on how to set the ports, take a look at the readme.

This fixes #34 