### PR TITLE
[Enchancement] Switch from username to email in sign-up and login #41

### DIFF
--- a/client/components/login/__snapshots__/login.test.js.snap
+++ b/client/components/login/__snapshots__/login.test.js.snap
@@ -53,26 +53,26 @@ exports[`<Login /> rendering should render correctly with social links 1`] = `
         >
           <React.Fragment>
             <label
-              className="owisp-login-label owisp-login-label-username"
-              htmlFor="owisp-login-username"
+              className="owisp-login-label owisp-login-label-email"
+              htmlFor="owisp-login-email"
             >
               <div
                 className="owisp-login-label-text"
               >
-                username
+                email
               </div>
               <input
                 className="owisp-login-input
-                      owisp-login-input-username
-                      "
-                id="owisp-login-username"
-                name="username"
+                        owisp-login-input-email
+                        "
+                id="owisp-login-email"
+                name="email"
                 onChange={[Function]}
-                pattern="[a-zA-Z@.+\\\\-_\\\\d]{1,150}"
-                placeholder="enter username"
+                pattern=".+@.+\\\\..+"
+                placeholder="email address"
                 required={true}
-                title="only letters, numbers, and @/./+/-/_ characters"
-                type="text"
+                title={null}
+                type="email"
                 value=""
               />
             </label>
@@ -259,26 +259,26 @@ exports[`<Login /> rendering should render correctly without social links 1`] = 
         >
           <React.Fragment>
             <label
-              className="owisp-login-label owisp-login-label-username"
-              htmlFor="owisp-login-username"
+              className="owisp-login-label owisp-login-label-email"
+              htmlFor="owisp-login-email"
             >
               <div
                 className="owisp-login-label-text"
               >
-                username
+                email
               </div>
               <input
                 className="owisp-login-input
-                      owisp-login-input-username
-                      "
-                id="owisp-login-username"
-                name="username"
+                        owisp-login-input-email
+                        "
+                id="owisp-login-email"
+                name="email"
                 onChange={[Function]}
-                pattern="[a-zA-Z@.+\\\\-_\\\\d]{1,150}"
-                placeholder="enter username"
+                pattern=".+@.+\\\\..+"
+                placeholder="email address"
                 required={true}
-                title="only letters, numbers, and @/./+/-/_ characters"
-                type="text"
+                title={null}
+                type="email"
                 value=""
               />
             </label>

--- a/client/components/login/login.js
+++ b/client/components/login/login.js
@@ -19,7 +19,7 @@ export default class Login extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      username: "",
+      email: "",
       password: "",
       errors: {},
     };
@@ -28,12 +28,12 @@ export default class Login extends React.Component {
   }
 
   componentDidMount() {
-    const username = getParameterByName("username");
+    const email = getParameterByName("email");
     const token = getParameterByName("token");
-    if (username && token) {
+    if (email && token) {
       this.setState(
         {
-          username,
+          email,
           password: token,
         },
         () => {
@@ -50,7 +50,7 @@ export default class Login extends React.Component {
   handleSubmit(event) {
     if (event) event.preventDefault();
     const {orgSlug, authenticate} = this.props;
-    const {username, password, errors} = this.state;
+    const {email, password, errors} = this.state;
     const url = loginApiUrl.replace("{orgSlug}", orgSlug);
     this.setState({
       errors: {},
@@ -62,7 +62,7 @@ export default class Login extends React.Component {
       },
       url,
       data: qs.stringify({
-        username,
+        "username": email,
         password,
       }),
     })
@@ -78,7 +78,7 @@ export default class Login extends React.Component {
               ? {nonField: data.non_field_errors[0]}
               : {nonField: ""}),
             ...(data.detail ? {nonField: data.detail} : {}),
-            ...(data.username ? {username: data.username} : {username: ""}),
+            ...(data.email ? {email: data.email.toString()} : {email: ""}),
             ...(data.password ? {password: data.password} : {password: ""}),
           },
         });
@@ -86,7 +86,7 @@ export default class Login extends React.Component {
   }
 
   render() {
-    const {errors, username, password} = this.state;
+    const {errors, email, password} = this.state;
     const {
       language,
       loginForm,
@@ -158,49 +158,49 @@ export default class Login extends React.Component {
                     </span>
                   </div>
                 )}
-                {input_fields.username ? (
+                {input_fields.email ? (
                   <>
                     <label
-                      className="owisp-login-label owisp-login-label-username"
-                      htmlFor="owisp-login-username"
+                      className="owisp-login-label owisp-login-label-email"
+                      htmlFor="owisp-login-email"
                     >
                       <div className="owisp-login-label-text">
-                        {getText(input_fields.username.label, language)}
+                        {getText(input_fields.email.label, language)}
                       </div>
                       <input
                         className={`owisp-login-input
-                      owisp-login-input-username
-                      ${errors.username ? "error" : ""}`}
-                        type={input_fields.username.type}
-                        id="owisp-login-username"
-                        name="username"
-                        value={username}
+                        owisp-login-input-email
+                        ${errors.email ? "error" : ""}`}
+                        type={input_fields.email.type}
+                        id="owisp-login-email"
+                        name="email"
+                        value={email}
                         onChange={this.handleChange}
                         required
                         placeholder={getText(
-                          input_fields.username.placeholder,
+                          input_fields.email.placeholder,
                           language,
                         )}
                         pattern={
-                          input_fields.username.pattern
-                            ? input_fields.username.pattern
+                          input_fields.email.pattern
+                            ? input_fields.email.pattern
                             : undefined
                         }
                         title={
-                          input_fields.username.pattern_description
+                          input_fields.email.pattern_description
                             ? getText(
-                                input_fields.username.pattern_description,
+                                input_fields.email.pattern_description,
                                 language,
                               )
                             : undefined
                         }
                       />
                     </label>
-                    {errors.username && (
-                      <div className="owisp-login-error owisp-login-error-username">
+                    {errors.email && (
+                      <div className="owisp-login-error owisp-login-error-email">
                         <span className="owisp-login-error-icon">!</span>
-                        <span className="owisp-login-error-text owisp-login-error-text-username">
-                          {errors.username}
+                        <span className="owisp-login-error-text owisp-login-error-text-email">
+                          {errors.email}
                         </span>
                       </div>
                     )}
@@ -345,8 +345,20 @@ Login.propTypes = {
       links: PropTypes.arrayOf(PropTypes.object),
     }),
     input_fields: PropTypes.shape({
-      username: PropTypes.object,
-      password: PropTypes.object,
+      email: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
+      password: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
     }),
     additional_info_text: PropTypes.object,
     buttons: PropTypes.object,

--- a/client/components/login/login.test.js
+++ b/client/components/login/login.test.js
@@ -70,9 +70,9 @@ describe("<Login /> interactions", () => {
   });
   it("should change state values when handleChange function is invoked", () => {
     wrapper
-      .find("#owisp-login-username")
-      .simulate("change", {target: {value: "test username", name: "username"}});
-    expect(wrapper.state("username")).toEqual("test username");
+      .find("#owisp-login-email")
+      .simulate("change", {target: {value: "test email", name: "email"}});
+    expect(wrapper.state("email")).toEqual("test email");
     wrapper
       .find("#owisp-login-password")
       .simulate("change", {target: {value: "test password", name: "password"}});
@@ -84,7 +84,7 @@ describe("<Login /> interactions", () => {
         return Promise.reject({
           response: {
             data: {
-              username: "username error",
+              email: "email error",
               password: "password error",
               detail: "error details",
               non_field_errors: "non field errors",
@@ -101,7 +101,7 @@ describe("<Login /> interactions", () => {
       .handleSubmit(event)
       .then(() => {
         expect(wrapper.instance().state.errors).toEqual({
-          username: "username error",
+          email: "email error",
           nonField: "error details",
           password: "password error",
         });

--- a/client/components/password-confirm/password-confirm.js
+++ b/client/components/password-confirm/password-confirm.js
@@ -255,7 +255,22 @@ PasswordConfirm.propTypes = {
   passwordConfirm: PropTypes.shape({
     heading: PropTypes.object,
     additional_text: PropTypes.object,
-    input_fields: PropTypes.object,
+    input_fields: PropTypes.shape({
+      password: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
+      password_confirm: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
+    }),
     buttons: PropTypes.object,
     login_page_link: PropTypes.object,
     contact_text: PropTypes.object,

--- a/client/components/password-reset/__snapshots__/password-reset.test.js.snap
+++ b/client/components/password-reset/__snapshots__/password-reset.test.js.snap
@@ -39,6 +39,7 @@ exports[`<PasswordReset /> rendering should render correctly 1`] = `
           id="owisp-password-reset-email"
           name="email"
           onChange={[Function]}
+          pattern=".+@.+\\\\..+"
           placeholder="email address"
           required={true}
           title={null}

--- a/client/components/password-reset/password-reset.js
+++ b/client/components/password-reset/password-reset.js
@@ -178,7 +178,15 @@ PasswordReset.propTypes = {
   passwordReset: PropTypes.shape({
     heading: PropTypes.object,
     additional_text: PropTypes.object,
-    input_fields: PropTypes.object,
+    input_fields: PropTypes.shape({
+      email: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
+    }),
     buttons: PropTypes.object,
     login_page_link: PropTypes.object,
     contact_text: PropTypes.object,

--- a/client/components/registration/__snapshots__/registration.test.js.snap
+++ b/client/components/registration/__snapshots__/registration.test.js.snap
@@ -17,32 +17,6 @@ exports[`<Registration /> rendering should render correctly 1`] = `
         >
           <React.Fragment>
             <label
-              className="owisp-registration-label owisp-registration-label-username"
-              htmlFor="owisp-registration-username"
-            >
-              <div
-                className="owisp-registration-label-text"
-              >
-                username
-              </div>
-              <input
-                className="owisp-registration-input
-                      owisp-registration-input-username
-                      "
-                id="owisp-registration-username"
-                name="username"
-                onChange={[Function]}
-                pattern="[a-zA-Z@.+\\\\-_\\\\d]{1,150}"
-                placeholder="enter username"
-                required={true}
-                title="only letters, numbers, and @/./+/-/_ characters"
-                type="text"
-                value=""
-              />
-            </label>
-          </React.Fragment>
-          <React.Fragment>
-            <label
               className="owisp-registration-label owisp-registration-label-email"
               htmlFor="owisp-registration-email"
             >
@@ -56,6 +30,7 @@ exports[`<Registration /> rendering should render correctly 1`] = `
                 id="owisp-registration-email"
                 name="email"
                 onChange={[Function]}
+                pattern=".+@.+\\\\..+"
                 placeholder="email address"
                 required={true}
                 title={null}

--- a/client/components/registration/registration.js
+++ b/client/components/registration/registration.js
@@ -17,7 +17,6 @@ export default class Registration extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      username: "",
       email: "",
       password1: "",
       password2: "",
@@ -36,7 +35,7 @@ export default class Registration extends React.Component {
     event.preventDefault();
     const {registration, orgSlug, authenticate} = this.props;
     const {input_fields} = registration;
-    const {username, email, password1, password2, errors} = this.state;
+    const {email, password1, password2, errors} = this.state;
     if (input_fields.password_confirm) {
       if (password1 !== password2) {
         this.setState({
@@ -57,7 +56,7 @@ export default class Registration extends React.Component {
       url,
       data: qs.stringify({
         email,
-        username,
+        "username": email,
         password1,
         password2,
       }),
@@ -65,7 +64,6 @@ export default class Registration extends React.Component {
       .then(() => {
         this.setState({
           errors: {},
-          username: "",
           email: "",
           password1: "",
           password2: "",
@@ -78,9 +76,6 @@ export default class Registration extends React.Component {
         this.setState({
           errors: {
             ...errors,
-            ...(data.username
-              ? {username: data.username.toString()}
-              : {username: ""}),
             ...(data.email ? {email: data.email.toString()} : {email: ""}),
             ...(data.password1
               ? {password1: data.password1.toString()}
@@ -106,7 +101,7 @@ export default class Registration extends React.Component {
       match,
     } = this.props;
     const {buttons, additional_info_text, input_fields, links} = registration;
-    const {username, email, password1, password2, errors, success} = this.state;
+    const {email, password1, password2, errors, success} = this.state;
     return (
       <React.Fragment>
         <div className="owisp-registration-container">
@@ -124,54 +119,6 @@ export default class Registration extends React.Component {
                     </span>
                   </div>
                 )}
-                {input_fields.username ? (
-                  <>
-                    <label
-                      className="owisp-registration-label owisp-registration-label-username"
-                      htmlFor="owisp-registration-username"
-                    >
-                      <div className="owisp-registration-label-text">
-                        {getText(input_fields.username.label, language)}
-                      </div>
-                      <input
-                        className={`owisp-registration-input
-                      owisp-registration-input-username
-                      ${errors.username ? "error" : ""}`}
-                        type={input_fields.username.type}
-                        id="owisp-registration-username"
-                        name="username"
-                        value={username}
-                        onChange={this.handleChange}
-                        required
-                        placeholder={getText(
-                          input_fields.username.placeholder,
-                          language,
-                        )}
-                        pattern={
-                          input_fields.username.pattern
-                            ? input_fields.username.pattern
-                            : undefined
-                        }
-                        title={
-                          input_fields.username.pattern_description
-                            ? getText(
-                                input_fields.username.pattern_description,
-                                language,
-                              )
-                            : undefined
-                        }
-                      />
-                    </label>
-                    {errors.username && (
-                      <div className="owisp-registration-error owisp-registration-error-username">
-                        <span className="owisp-registration-error-icon">!</span>
-                        <span className="owisp-registration-error-text owisp-registration-error-text-username">
-                          {errors.username}
-                        </span>
-                      </div>
-                    )}
-                  </>
-                ) : null}
 
                 {input_fields.email ? (
                   <>
@@ -396,10 +343,27 @@ Registration.propTypes = {
       register: PropTypes.object,
     }),
     input_fields: PropTypes.shape({
-      email: PropTypes.object,
-      password: PropTypes.object,
-      password_confirm: PropTypes.object,
-      username: PropTypes.object,
+      email: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
+      password: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
+      password_confirm: PropTypes.shape({
+        type: PropTypes.string.isRequired,
+        label: PropTypes.object,
+        placeholder: PropTypes.object,
+        pattern: PropTypes.string,
+        pattern_description: PropTypes.object
+      }),
     }),
     additional_info_text: PropTypes.object,
     links: PropTypes.object,

--- a/client/components/registration/registration.test.js
+++ b/client/components/registration/registration.test.js
@@ -48,10 +48,6 @@ describe("<Registration /> interactions", () => {
   });
   it("should change state values when handleChange function is invoked", () => {
     wrapper
-      .find("#owisp-registration-username")
-      .simulate("change", {target: {value: "test username", name: "username"}});
-    expect(wrapper.state("username")).toEqual("test username");
-    wrapper
       .find("#owisp-registration-email")
       .simulate("change", {target: {value: "test email", name: "email"}});
     expect(wrapper.state("email")).toEqual("test email");
@@ -71,7 +67,6 @@ describe("<Registration /> interactions", () => {
         return Promise.reject({
           response: {
             data: {
-              username: "username error",
               email: "email error",
               detail: "nonField error",
               password1: "password1 error",
@@ -109,13 +104,12 @@ describe("<Registration /> interactions", () => {
       .handleSubmit(event)
       .then(() => {
         expect(wrapper.instance().state.errors).toEqual({
-          username: "username error",
           email: "email error",
           nonField: "nonField error",
           password1: "password1 error",
           password2: "",
         });
-        expect(wrapper.find(".owisp-registration-error")).toHaveLength(4);
+        expect(wrapper.find(".owisp-registration-error")).toHaveLength(3);
       })
       .then(() => {
         return wrapper

--- a/org-configurations/default-configuration.yml
+++ b/org-configurations/default-configuration.yml
@@ -75,7 +75,7 @@ client:
             en: "username"
         email:
           type: "email"
-          pattern: null
+          pattern: '.+@.+\..+'
           pattern_description:
             en: null
           placeholder:
@@ -119,7 +119,7 @@ client:
       input_fields:
         email:
           type: "email"
-          pattern: null
+          pattern: '.+@.+\..+'
           pattern_description:
             en: null
           placeholder:
@@ -217,15 +217,15 @@ client:
             icon: "twitter.svg"
             url: "#"
       input_fields:
-        username:
-          type: "text"
-          pattern: '[a-zA-Z@.+\-_\d]{1,150}'
+        email:
+          type: "email"
+          pattern: '.+@.+\..+'
           pattern_description:
-            en: "only letters, numbers, and @/./+/-/_ characters"
+            en: null
           placeholder:
-            en: "enter username"
+            en: "email address"
           label:
-            en: "username"
+            en: "email"
         password:
           type: "password"
           pattern: ".{6,}"


### PR DESCRIPTION
This is a PR for commit which switches `openwisp-wifi-login-pages` from username to email in sign-up and login by using email instead of username on frontend side of the application and sending email to server as a value of `username` (so it doesn't change backend part).
***
##### Changes:
 - Updated `login.js` :
   - Switched from username `input_field` to email `input_field`
   - Changed state (now it works with `email` & `password`)
 - Updated `registration.js` :
   - Changed state (now it works with `email`, `password1` and `password2`)
   - Removed username `input_field`
 - Updated `default-configuration.yml`:
   - Switched from `username` to `email` in `input_field`  of `login_form`
 - Updated tests (`login.test.js` and `registration.test.js`)
 - Updated snapshots (`login.test.js.snap` and `registration.test.js.snap`)
***
Fixes #41