### PR TITLE
[#90] remove <div> from inside <label>

### DIFF
--- a/client/components/login/__snapshots__/login.test.js.snap
+++ b/client/components/login/__snapshots__/login.test.js.snap
@@ -53,14 +53,10 @@ exports[`<Login /> rendering should render correctly with social links 1`] = `
         >
           <React.Fragment>
             <label
-              className="owisp-login-label owisp-login-label-email"
+              className="owisp-login-label owisp-login-label-text owisp-login-label-email"
               htmlFor="owisp-login-email"
             >
-              <div
-                className="owisp-login-label-text"
-              >
-                email
-              </div>
+              email
               <input
                 className="owisp-login-input
                         owisp-login-input-email
@@ -79,14 +75,10 @@ exports[`<Login /> rendering should render correctly with social links 1`] = `
           </React.Fragment>
           <React.Fragment>
             <label
-              className="owisp-login-label owisp-login-label-password"
+              className="owisp-login-label owisp-login-label-text owisp-login-label-password"
               htmlFor="owisp-login-password"
             >
-              <div
-                className="owisp-login-label-text"
-              >
-                password
-              </div>
+              password
               <input
                 className="owisp-login-input owisp-login-input-password
                       "
@@ -132,14 +124,10 @@ exports[`<Login /> rendering should render correctly with social links 1`] = `
         </React.Fragment>
         <React.Fragment>
           <label
-            className="owisp-login-label owisp-login-label-register-btn"
+            className="owisp-login-label owisp-login-label-text owisp-login-label-register-btn"
             htmlFor="owisp-login-register-btn"
           >
-            <div
-              className="owisp-login-label-text"
-            >
-              Not registered yet?
-            </div>
+            Not registered yet?
           </label>
           <div
             className="owisp-login-form-register-btn-div"
@@ -259,14 +247,10 @@ exports[`<Login /> rendering should render correctly without social links 1`] = 
         >
           <React.Fragment>
             <label
-              className="owisp-login-label owisp-login-label-email"
+              className="owisp-login-label owisp-login-label-text owisp-login-label-email"
               htmlFor="owisp-login-email"
             >
-              <div
-                className="owisp-login-label-text"
-              >
-                email
-              </div>
+              email
               <input
                 className="owisp-login-input
                         owisp-login-input-email
@@ -285,14 +269,10 @@ exports[`<Login /> rendering should render correctly without social links 1`] = 
           </React.Fragment>
           <React.Fragment>
             <label
-              className="owisp-login-label owisp-login-label-password"
+              className="owisp-login-label owisp-login-label-text owisp-login-label-password"
               htmlFor="owisp-login-password"
             >
-              <div
-                className="owisp-login-label-text"
-              >
-                password
-              </div>
+              password
               <input
                 className="owisp-login-input owisp-login-input-password
                       "
@@ -338,14 +318,10 @@ exports[`<Login /> rendering should render correctly without social links 1`] = 
         </React.Fragment>
         <React.Fragment>
           <label
-            className="owisp-login-label owisp-login-label-register-btn"
+            className="owisp-login-label owisp-login-label-text owisp-login-label-register-btn"
             htmlFor="owisp-login-register-btn"
           >
-            <div
-              className="owisp-login-label-text"
-            >
-              Not registered yet?
-            </div>
+            Not registered yet?
           </label>
           <div
             className="owisp-login-form-register-btn-div"

--- a/client/components/login/login.js
+++ b/client/components/login/login.js
@@ -173,12 +173,10 @@ export default class Login extends React.Component {
                 {input_fields.email ? (
                   <>
                     <label
-                      className="owisp-login-label owisp-login-label-email"
+                      className="owisp-login-label owisp-login-label-text owisp-login-label-email"
                       htmlFor="owisp-login-email"
                     >
-                      <div className="owisp-login-label-text">
-                        {getText(input_fields.email.label, language)}
-                      </div>
+                      {getText(input_fields.email.label, language)}
                       <input
                         className={`owisp-login-input
                         owisp-login-input-email
@@ -221,12 +219,10 @@ export default class Login extends React.Component {
                 {input_fields.password ? (
                   <>
                     <label
-                      className="owisp-login-label owisp-login-label-password"
+                      className="owisp-login-label owisp-login-label-text owisp-login-label-password"
                       htmlFor="owisp-login-password"
                     >
-                      <div className="owisp-login-label-text">
-                        {getText(input_fields.password.label, language)}
-                      </div>
+                      {getText(input_fields.password.label, language)}
                       <input
                         className={`owisp-login-input owisp-login-input-password
                       ${errors.password1 ? "error" : ""}`}
@@ -282,12 +278,10 @@ export default class Login extends React.Component {
                 <>
                   {buttons.login.label ? (
                     <label
-                      className="owisp-login-label owisp-login-label-login-btn"
+                      className="owisp-login-label owisp-login-label-text owisp-login-label-login-btn"
                       htmlFor="owisp-login-login-btn"
                     >
-                      <div className="owisp-login-label-text">
-                        {getText(buttons.login.label, language)}
-                      </div>
+                      {getText(buttons.login.label, language)}
                     </label>
                   ) : null}
                   <input
@@ -302,12 +296,10 @@ export default class Login extends React.Component {
                 <>
                   {buttons.register.label ? (
                     <label
-                      className="owisp-login-label owisp-login-label-register-btn"
+                      className="owisp-login-label owisp-login-label-text owisp-login-label-register-btn"
                       htmlFor="owisp-login-register-btn"
                     >
-                      <div className="owisp-login-label-text">
-                        {getText(buttons.register.label, language)}
-                      </div>
+                      {getText(buttons.register.label, language)}
                     </label>
                   ) : null}
                   <div className="owisp-login-form-register-btn-div">

--- a/client/components/password-change/__snapshots__/password-change.test.js.snap
+++ b/client/components/password-change/__snapshots__/password-change.test.js.snap
@@ -16,14 +16,10 @@ exports[`<PasswordChange /> rendering should render correctly 1`] = `
       </div>
       <React.Fragment>
         <label
-          className="owisp-password-change-label owisp-password-change-label-password"
+          className="owisp-password-change-label owisp-password-change-label-text owisp-password-change-label-password"
           htmlFor="owisp-password-change-password"
         >
-          <div
-            className="owisp-password-change-label-text"
-          >
-            New Password
-          </div>
+          New Password
           <input
             className="owisp-password-change-input owisp-password-change-input-password"
             id="owisp-password-change-password"
@@ -39,14 +35,10 @@ exports[`<PasswordChange /> rendering should render correctly 1`] = `
       </React.Fragment>
       <React.Fragment>
         <label
-          className="owisp-password-change-label owisp-password-change-label-password-confirm"
+          className="owisp-password-change-label owisp-password-change-label-text owisp-password-change-label-password-confirm"
           htmlFor="owisp-password-change-password-confirm"
         >
-          <div
-            className="owisp-password-change-label-text"
-          >
-            New Password
-          </div>
+          New Password
           <input
             className="owisp-password-change-input owisp-password-change-input-password-confirm"
             id="owisp-password-change-password-confirm"

--- a/client/components/password-change/password-change.js
+++ b/client/components/password-change/password-change.js
@@ -94,15 +94,13 @@ export default class PasswordChange extends React.Component {
             {passwordChange.input_fields.password1 ? (
               <>
                 <label
-                  className="owisp-password-change-label owisp-password-change-label-password"
+                  className="owisp-password-change-label owisp-password-change-label-text owisp-password-change-label-password"
                   htmlFor="owisp-password-change-password"
                 >
-                  <div className="owisp-password-change-label-text">
-                    {getText(
-                      passwordChange.input_fields.password1.label,
-                      language,
-                    )}
-                  </div>
+                  {getText(
+                    passwordChange.input_fields.password1.label,
+                    language,
+                  )}
                   <input
                     className="owisp-password-change-input owisp-password-change-input-password"
                     type="password"
@@ -135,15 +133,13 @@ export default class PasswordChange extends React.Component {
             {passwordChange.input_fields.password2 ? (
               <>
                 <label
-                  className="owisp-password-change-label owisp-password-change-label-password-confirm"
+                  className="owisp-password-change-label owisp-password-change-label-text owisp-password-change-label-password-confirm"
                   htmlFor="owisp-password-change-password-confirm"
                 >
-                  <div className="owisp-password-change-label-text">
-                    {getText(
-                      passwordChange.input_fields.password1.label,
-                      language,
-                    )}
-                  </div>
+                  {getText(
+                    passwordChange.input_fields.password1.label,
+                    language,
+                  )}
                   <input
                     className="owisp-password-change-input owisp-password-change-input-password-confirm"
                     type="password"

--- a/client/components/password-confirm/__snapshots__/password-confirm.test.js.snap
+++ b/client/components/password-confirm/__snapshots__/password-confirm.test.js.snap
@@ -26,14 +26,10 @@ exports[`<PasswordConfirm /> rendering should render correctly 1`] = `
       className="owisp-password-confirm-fieldset"
     >
       <label
-        className="owisp-password-confirm-label owisp-password-confirm-label-password"
+        className="owisp-password-confirm-label owisp-password-confirm-label-text owisp-password-confirm-label-password"
         htmlFor="owisp-password-confirm-password"
       >
-        <div
-          className="owisp-password-confirm-label-text"
-        >
-          password
-        </div>
+        password
         <input
           className="owisp-password-confirm-input owisp-password-confirm-input-password
                       "
@@ -49,14 +45,10 @@ exports[`<PasswordConfirm /> rendering should render correctly 1`] = `
         />
       </label>
       <label
-        className="owisp-password-confirm-label owisp-password-confirm-label-confirm"
+        className="owisp-password-confirm-label owisp-password-confirm-label-text owisp-password-confirm-label-confirm"
         htmlFor="owisp-password-confirm-password-confirm"
       >
-        <div
-          className="owisp-password-confirm-label-text"
-        >
-          confirm
-        </div>
+        confirm
         <input
           className="owisp-password-confirm-input owisp-password-confirm-input-confirm "
           id="owisp-password-confirm-password-confirm"

--- a/client/components/password-confirm/password-confirm.js
+++ b/client/components/password-confirm/password-confirm.js
@@ -130,12 +130,10 @@ export default class PasswordConfirm extends React.Component {
                   {inputFields.password ? (
                     <>
                       <label
-                        className="owisp-password-confirm-label owisp-password-confirm-label-password"
+                        className="owisp-password-confirm-label owisp-password-confirm-label-text owisp-password-confirm-label-password"
                         htmlFor="owisp-password-confirm-password"
                       >
-                        <div className="owisp-password-confirm-label-text">
-                          {getText(inputFields.password.label, language)}
-                        </div>
+                        {getText(inputFields.password.label, language)}
                         <input
                           className={`owisp-password-confirm-input owisp-password-confirm-input-password
                       ${errors.newPassword1 ? "error" : ""}`}
@@ -180,12 +178,10 @@ export default class PasswordConfirm extends React.Component {
                   {inputFields.password_confirm ? (
                     <>
                       <label
-                        className="owisp-password-confirm-label owisp-password-confirm-label-confirm"
+                        className="owisp-password-confirm-label owisp-password-confirm-label-text owisp-password-confirm-label-confirm"
                         htmlFor="owisp-password-confirm-password-confirm"
                       >
-                        <div className="owisp-password-confirm-label-text">
-                          {getText(inputFields.password_confirm.label, language)}
-                        </div>
+                        {getText(inputFields.password_confirm.label, language)}
                         <input
                           className={`owisp-password-confirm-input owisp-password-confirm-input-confirm ${
                             errors.newPassword2 ? "error" : ""

--- a/client/components/password-reset/__snapshots__/password-reset.test.js.snap
+++ b/client/components/password-reset/__snapshots__/password-reset.test.js.snap
@@ -26,27 +26,23 @@ exports[`<PasswordReset /> rendering should render correctly 1`] = `
       className="owisp-password-reset-fieldset"
     >
       <label
-        className="owisp-password-reset-label owisp-password-reset-label-email"
+        className="owisp-password-reset-label owisp-password-reset-label-text owisp-password-reset-label-email"
         htmlFor="owisp-password-reset-email"
       >
-        <div
-          className="owisp-password-reset-label-text owisp-password-reset-label-text-email"
-        >
-          email
-        </div>
-        <input
-          className="owisp-password-reset-input owisp-password-reset-input-email "
-          id="owisp-password-reset-email"
-          name="email"
-          onChange={[Function]}
-          pattern=".+@.+\\\\..+"
-          placeholder="email address"
-          required={true}
-          title={null}
-          type="email"
-          value=""
-        />
+        email
       </label>
+      <input
+        className="owisp-password-reset-input owisp-password-reset-input-email "
+        id="owisp-password-reset-email"
+        name="email"
+        onChange={[Function]}
+        pattern=".+@.+\\\\..+"
+        placeholder="email address"
+        required={true}
+        title={null}
+        type="email"
+        value=""
+      />
     </div>
     <input
       className="owisp-password-reset-send-btn owisp-btn-primary"

--- a/client/components/password-reset/password-reset.js
+++ b/client/components/password-reset/password-reset.js
@@ -105,41 +105,39 @@ export default class PasswordReset extends React.Component {
                   {inputFields.email ? (
                     <>
                       <label
-                        className="owisp-password-reset-label owisp-password-reset-label-email"
+                        className="owisp-password-reset-label owisp-password-reset-label-text owisp-password-reset-label-email"
                         htmlFor="owisp-password-reset-email"
                       >
-                        <div className="owisp-password-reset-label-text owisp-password-reset-label-text-email">
-                          {getText(inputFields.email.label, language)}
-                        </div>
-                        <input
-                          className={`owisp-password-reset-input owisp-password-reset-input-email ${
-                            errors.email ? "error" : ""
-                            }`}
-                          type={inputFields.email.type}
-                          id="owisp-password-reset-email"
-                          required
-                          name="email"
-                          value={email}
-                          onChange={this.handleChange}
-                          placeholder={getText(
-                            inputFields.email.placeholder,
-                            language,
-                          )}
-                          pattern={
-                            inputFields.email.pattern
-                              ? inputFields.email.pattern
-                              : undefined
-                          }
-                          title={
-                            inputFields.email.pattern_description
-                              ? getText(
-                                inputFields.email.pattern_description,
-                                language,
-                              )
-                              : undefined
-                          }
-                        />
+                        {getText(inputFields.email.label, language)}
                       </label>
+                      <input
+                        className={`owisp-password-reset-input owisp-password-reset-input-email ${
+                          errors.email ? "error" : ""
+                          }`}
+                        type={inputFields.email.type}
+                        id="owisp-password-reset-email"
+                        required
+                        name="email"
+                        value={email}
+                        onChange={this.handleChange}
+                        placeholder={getText(
+                          inputFields.email.placeholder,
+                          language,
+                        )}
+                        pattern={
+                          inputFields.email.pattern
+                            ? inputFields.email.pattern
+                            : undefined
+                        }
+                        title={
+                          inputFields.email.pattern_description
+                            ? getText(
+                              inputFields.email.pattern_description,
+                              language,
+                            )
+                            : undefined
+                        }
+                      />
                       {errors.email && (
                         <div className="owisp-password-reset-error owisp-password-reset-error-email">
                           <span className="owisp-password-reset-error-icon">

--- a/client/components/registration/__snapshots__/registration.test.js.snap
+++ b/client/components/registration/__snapshots__/registration.test.js.snap
@@ -17,14 +17,10 @@ exports[`<Registration /> rendering should render correctly 1`] = `
         >
           <React.Fragment>
             <label
-              className="owisp-registration-label owisp-registration-label-email"
+              className="owisp-registration-label owisp-registration-label-text owisp-registration-label-email"
               htmlFor="owisp-registration-email"
             >
-              <div
-                className="owisp-registration-label-text owisp-registration-label-text-email"
-              >
-                email
-              </div>
+              email
               <input
                 className="owisp-registration-input owisp-registration-input-email "
                 id="owisp-registration-email"
@@ -41,14 +37,10 @@ exports[`<Registration /> rendering should render correctly 1`] = `
           </React.Fragment>
           <React.Fragment>
             <label
-              className="owisp-registration-label owisp-registration-label-password"
+              className="owisp-registration-label owisp-registration-label-text owisp-registration-label-password"
               htmlFor="owisp-registration-password"
             >
-              <div
-                className="owisp-registration-label-text"
-              >
-                password
-              </div>
+              password
               <input
                 className="owisp-registration-input owisp-registration-input-password
                       "
@@ -66,14 +58,10 @@ exports[`<Registration /> rendering should render correctly 1`] = `
           </React.Fragment>
           <React.Fragment>
             <label
-              className="owisp-registration-label owisp-registration-label-confirm"
+              className="owisp-registration-label owisp-registration-label-text owisp-registration-label-confirm"
               htmlFor="owisp-registration-password-confirm"
             >
-              <div
-                className="owisp-registration-label-text"
-              >
-                confirm
-              </div>
+              confirm
               <input
                 className="owisp-registration-input owisp-registration-input-confirm "
                 id="owisp-registration-password-confirm"

--- a/client/components/registration/registration.js
+++ b/client/components/registration/registration.js
@@ -135,12 +135,10 @@ export default class Registration extends React.Component {
                 {input_fields.email ? (
                   <>
                     <label
-                      className="owisp-registration-label owisp-registration-label-email"
+                      className="owisp-registration-label owisp-registration-label-text owisp-registration-label-email"
                       htmlFor="owisp-registration-email"
                     >
-                      <div className="owisp-registration-label-text owisp-registration-label-text-email">
-                        {getText(input_fields.email.label, language)}
-                      </div>
+                      {getText(input_fields.email.label, language)}
                       <input
                         className={`owisp-registration-input owisp-registration-input-email ${
                           errors.email ? "error" : ""
@@ -184,12 +182,10 @@ export default class Registration extends React.Component {
                 {input_fields.password ? (
                   <>
                     <label
-                      className="owisp-registration-label owisp-registration-label-password"
+                      className="owisp-registration-label owisp-registration-label-text owisp-registration-label-password"
                       htmlFor="owisp-registration-password"
                     >
-                      <div className="owisp-registration-label-text">
-                        {getText(input_fields.password.label, language)}
-                      </div>
+                      {getText(input_fields.password.label, language)}
                       <input
                         className={`owisp-registration-input owisp-registration-input-password
                       ${errors.password1 ? "error" : ""}`}
@@ -232,12 +228,10 @@ export default class Registration extends React.Component {
                 {input_fields.password_confirm ? (
                   <>
                     <label
-                      className="owisp-registration-label owisp-registration-label-confirm"
+                      className="owisp-registration-label owisp-registration-label-text owisp-registration-label-confirm"
                       htmlFor="owisp-registration-password-confirm"
                     >
-                      <div className="owisp-registration-label-text">
-                        {getText(input_fields.password_confirm.label, language)}
-                      </div>
+                      {getText(input_fields.password_confirm.label, language)}
                       <input
                         className={`owisp-registration-input owisp-registration-input-confirm ${
                           errors.password2 ? "error" : ""
@@ -295,12 +289,10 @@ export default class Registration extends React.Component {
                 <>
                   {buttons.register.label ? (
                     <label
-                      className="owisp-registration-label owisp-registration-label-registration-btn"
+                      className="owisp-registration-label owisp-registration-label-text owisp-registration-label-registration-btn"
                       htmlFor="owisp-registration-registration-btn"
                     >
-                      <div className="owisp-registration-label-text">
-                        {getText(buttons.register.label, language)}
-                      </div>
+                      {getText(buttons.register.label, language)}
                     </label>
                   ) : null}
                   <input

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -233,12 +233,10 @@ export default class Status extends React.Component {
                   {buttons.logout.label ? (
                     <>
                       <label
-                        className="owisp-status-label owisp-status-label-logout-btn"
+                        className="owisp-status-label owisp-status-label-text owisp-status-label-logout-btn"
                         htmlFor="owisp-status-logout-btn"
                       >
-                        <div className="owisp-status-label-text">
-                          {getText(buttons.logout.label, language)}
-                        </div>
+                        {getText(buttons.logout.label, language)}
                       </label>
                     </>
                   ) : null}


### PR DESCRIPTION
Made the following changes:
- Removed `<div>` from inside `<label>` in login.js, password-change.js, password-confirm.js, password-reset.js, registration.js, status.js.
- Updated test snapshots (it wasn't requested but thought it would be necessary anyway)

**Note:** I wasn't able to preview every view before making some of the changes to verify that the styling was unchanged. I tried to register a dummy account but received a 500 error. Do let me know the correct way to create a dummy account for development, if possible.