### PR TITLE
[doc] Added minimum node & npm version required#78

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,8 +22,8 @@ Openwisp wifi login pages app to allow users to authenticate, sign up and know m
 
 ### Prerequisites
 
-- [NodeJs](https://nodejs.org/en/)
-- [NPM](https://npmjs.org/) - Node package manager
+- [NodeJs](https://nodejs.org/en/) >= 12.0.0
+- [NPM](https://npmjs.org/) - Node package manager >= 6.9.0
 
 ### Install
 


### PR DESCRIPTION
Ran tests on node versions 10.x.x & 11.x.x, either tests were failing or warnings were there. 
Worked fine for v12.0.0 or above
Closes #78