### PR TITLE
[footer] Fix unique key props error #169

### DIFF
--- a/client/components/footer/footer.js
+++ b/client/components/footer/footer.js
@@ -24,7 +24,7 @@ export default class Footer extends React.Component {
                   footer-link-${index + 1}`}
                     target="_blank"
                     rel="noreferrer noopener"
-                    key={link}
+                    key={index}
                   >
                     {getText(link.text, language)}
                   </a>

--- a/client/components/footer/footer.js
+++ b/client/components/footer/footer.js
@@ -24,7 +24,7 @@ export default class Footer extends React.Component {
                   footer-link-${index + 1}`}
                     target="_blank"
                     rel="noreferrer noopener"
-                    key={link.url}
+                    key={link}
                   >
                     {getText(link.text, language)}
                   </a>


### PR DESCRIPTION
Just had to change the key. 
Earlier the key was the URL itself, and when no link was present in the footer, a unique key prop error would come.

Fixes #169