### PR TITLE
Fixed unique key prop error issue#182

### DIFF
--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -537,10 +537,9 @@ export default class Status extends React.Component {
               {links && links.map(link => {
                 if (shouldLinkBeShown(link, isAuthenticated)) {
                   return (
-                    <div className="links row">
+                    <div className="links row" key={link}>
                       <Link
                         className="button full status-link"
-                        key={link.url}
                         to={link.url.replace("{orgSlug}", orgSlug)}
                       >
                         {getText(link.text, language)}


### PR DESCRIPTION
Instead of using the react-uuid module, we can simply put this key in the outer div so that when multiple renders occurs react will know it is the same key or different key or it has to render the element or not.

@niteshsinha17 please review this PR :-)