### PR TITLE
[fix] Fixes unique key props error

### DIFF
--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -537,10 +537,9 @@ export default class Status extends React.Component {
               {links && links.map(link => {
                 if (shouldLinkBeShown(link, isAuthenticated)) {
                   return (
-                    <div className="links row">
+                    <div className="links row" key={link}>
                       <Link
                         className="button full status-link"
-                        key={link.url}
                         to={link.url.replace("{orgSlug}", orgSlug)}
                       >
                         {getText(link.text, language)}

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -537,7 +537,7 @@ export default class Status extends React.Component {
               {links && links.map(link => {
                 if (shouldLinkBeShown(link, isAuthenticated)) {
                   return (
-                    <div className="links row" key={link}>
+                    <div className="links row" key={link.url}>
                       <Link
                         className="button full status-link"
                         to={link.url.replace("{orgSlug}", orgSlug)}


### PR DESCRIPTION
Problem was key was being set to inner link it should be on outer div so when multiple renders occur react will know the key is same or not or it has to render element or not.

@niteshsinha17 Please review this PR.