### PR TITLE
[Fix] Separated webpack analyzer plugin from main plugins #223

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ This tool helps to keep the size of the JS files produced by the app in check.
 Run it with:
 
 ```
-npx webpack-cli --profile --json --config config/webpack.config.js > compilation-stats.json
+yarn stats
 ```
 
 ### Settings

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -19,6 +19,38 @@ module.exports = (env, argv) => {
 
   let clientP = process.env.CLIENT;
 
+  let plugins = [
+    new CleanWebpackPlugin(),
+    new HtmlWebpackPlugin({
+      filename: "index.html",
+      template: path.resolve(CURRENT_WORKING_DIR, "public/index.html"),
+    }),
+    new HardSourceWebpackPlugin(),
+    new CompressionPlugin({
+      filename: "[path].gz[query]",
+      algorithm: "gzip",
+      test: /\.js$|\.css$|\.html$/,
+      threshold: 10240,
+      minRatio: 0.8,
+    }),
+    new CopyPlugin({
+      patterns: [
+        {
+          from: path.resolve(CURRENT_WORKING_DIR, "client/assets"),
+          to: path.resolve(CURRENT_WORKING_DIR, "dist/assets"),
+        },
+      ],
+    }),
+  ];
+
+  if (process.env.STATS)
+    plugins.push(
+      new BundleAnalyzerPlugin({
+        analyzerMode: "disabled",
+        generateStatsFile: true,
+      }),
+    );
+
   // The url the server is running on; if none was given, fall back to the default
   let serverUrl;
   if (process.env.SERVER != undefined) {
@@ -69,30 +101,7 @@ module.exports = (env, argv) => {
       ],
     },
 
-    plugins: [
-      new BundleAnalyzerPlugin(),
-      new CleanWebpackPlugin(),
-      new HtmlWebpackPlugin({
-        filename: "index.html",
-        template: path.resolve(CURRENT_WORKING_DIR, "public/index.html"),
-      }),
-      new HardSourceWebpackPlugin(),
-      new CompressionPlugin({
-        filename: "[path].gz[query]",
-        algorithm: "gzip",
-        test: /\.js$|\.css$|\.html$/,
-        threshold: 10240,
-        minRatio: 0.8,
-      }),
-      new CopyPlugin({
-        patterns: [
-          {
-            from: path.resolve(CURRENT_WORKING_DIR, "client/assets"),
-            to: path.resolve(CURRENT_WORKING_DIR, "dist/assets"),
-          },
-        ],
-      }),
-    ],
+    plugins: plugins,
 
     devServer: {
       port: clientP,

--- a/package.json
+++ b/package.json
@@ -99,7 +99,8 @@
     "format": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",
     "format:check": "prettier -c \"**/*.+(js|jsx|json|css|md)\"",
     "test": "jest",
-    "test-inspect": "node inspect ./node_modules/.bin/jest --runInBand"
+    "test-inspect": "node inspect ./node_modules/.bin/jest --runInBand",
+    "stats": "STATS=true npx webpack-cli --profile --json --config config/webpack.config.js > compilation-stats.json && webpack-bundle-analyzer dist/stats.json"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Now webpack analyzer can be avoided during the standard build process and yarn start

Fixes #223