### PR TITLE
[change/fix] Wait until captive portal login response #265

### DIFF
--- a/browser-test/clear_data.py
+++ b/browser-test/clear_data.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import django
+import swapper
 
 
 def load_test_data():
@@ -37,7 +38,9 @@ except ImportError:
 from django.contrib.auth import get_user_model
 
 User = get_user_model()
+RadiusAccounting = swapper.load_model('openwisp_radius', 'RadiusAccounting')
 
 test_data = load_test_data()
 
 User.objects.filter(username=test_data['testuser']['email']).delete()
+RadiusAccounting.objects.filter(username=test_data['testuser']['email']).delete()

--- a/browser-test/initialize_data.py
+++ b/browser-test/initialize_data.py
@@ -51,12 +51,9 @@ if registration_tests:
     User.objects.filter(username=test_user_email).delete()
     sys.exit(0)
 
-user = User.objects.create_user(
-    username=test_user_email, password=test_user_password, email=test_user_email
-)
 try:
     org = Organization.objects.get(slug=test_user_organization)
-except:
+except Organization.DoesNotExist:
     print(
         (
             f'The organization {test_user_organization} does not exist in the OpenWISP Radius'
@@ -65,4 +62,8 @@ except:
         file=sys.stderr,
     )
     sys.exit(2)
+
+user = User.objects.create_user(
+    username=test_user_email, password=test_user_password, email=test_user_email
+)
 OrganizationUser.objects.create(organization=org, user=user)

--- a/browser-test/login.test.js
+++ b/browser-test/login.test.js
@@ -44,5 +44,11 @@ describe("Selenium tests for <Login />", () => {
     await driver.wait(until.elementIsVisible(successToastDiv));
     await driver.wait(until.urlContains("status"), 5000);
     expect(await successToastDiv.getText()).toEqual("Login successful");
+
+    const activeSessionTr = await getElementByCss(
+      driver,
+      "table tr.active-session",
+    );
+    await driver.wait(until.elementIsVisible(activeSessionTr));
   });
 });

--- a/client/components/login/login.js
+++ b/client/components/login/login.js
@@ -168,7 +168,7 @@ export default class Login extends React.Component {
   handleSubmit(event) {
     const {setLoading} = this.context;
     if (event) event.preventDefault();
-    const {orgSlug, authenticate, settings, setUserData} = this.props;
+    const {orgSlug, authenticate, setUserData} = this.props;
     const {username, password, remember_me, errors} = this.state;
     const url = loginApiUrl(orgSlug);
     this.setState({
@@ -183,11 +183,11 @@ export default class Login extends React.Component {
       if (!remember_me) {
         sessionStorage.setItem(`${orgSlug}_auth_token`, data.key);
       }
-      authenticate(true);
       toast.success(loginSuccess, {
         toastId: mainToastId,
       });
       setUserData({...data, justAuthenticated: true});
+      authenticate(true);
     };
 
     return axios({
@@ -214,11 +214,7 @@ export default class Login extends React.Component {
         const {data} = error.response;
         if (!data) throw new Error();
 
-        if (
-          error.response.status === 401 &&
-          settings.mobile_phone_verification &&
-          data.is_active
-        ) {
+        if (error.response.status === 401 && data.is_active) {
           handleAuthentication(data);
           return;
         }


### PR DESCRIPTION
Wait until captive portal login response to perform actions like:

- clearing the loading overlay
- redirecting the user to payment flow
- loading user sessions

Fixes #265