### PR TITLE
[ci] Used yarn test before installing openwisp-radius #316

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,9 @@ jobs:
           yarn install
           yarn setup
 
+      - name: Tests
+        run: yarn coverage
+
       - name: Installing OpenWISP Radius
         run: |
           git clone https://github.com/openwisp/openwisp-radius/
@@ -84,9 +87,6 @@ jobs:
 
       - name: Running OpenWISP WiFi Login Pages
         run: yarn start &
-
-      - name: Tests
-        run: yarn coverage
 
       - name: geckodriver/firefox
         run: |


### PR DESCRIPTION
~~Refactor CI file~~ Changed order of build steps to run headless jasmine tests before running the browser based tests installing external dependencies to reduce CI time if tests fail.

Closes #316