### PR TITLE
[fix] Added setUserData to called after logout #343

### DIFF
--- a/client/components/mobile-phone-change/mobile-phone-change.test.js
+++ b/client/components/mobile-phone-change/mobile-phone-change.test.js
@@ -402,4 +402,15 @@ describe("Change Phone Number: corner cases", () => {
     wrapper = await mountComponent(props);
     expect(wrapper.find(Redirect)).toHaveLength(0);
   });
+
+  it("should validate token", async () => {
+    wrapper = await mountComponent(props);
+    expect(validateToken).toHaveBeenCalledWith(
+      props.cookies,
+      props.orgSlug,
+      props.setUserData,
+      props.userData,
+      props.logout,
+    );
+  });
 });

--- a/client/components/mobile-phone-verification/mobile-phone-verification.js
+++ b/client/components/mobile-phone-verification/mobile-phone-verification.js
@@ -21,7 +21,7 @@ import handleChange from "../../utils/handle-change";
 import Contact from "../contact-box";
 import handleSession from "../../utils/session";
 import validateToken from "../../utils/validate-token";
-import {initialState} from "../../reducers/organization";
+import handleLogout from "../../utils/handle-logout";
 
 export default class MobilePhoneVerification extends React.Component {
   phoneTokenSentKey = "owPhoneTokenSent";
@@ -37,7 +37,6 @@ export default class MobilePhoneVerification extends React.Component {
     this.handleSubmit = this.handleSubmit.bind(this);
     this.handleChange = this.handleChange.bind(this);
     this.resendPhoneToken = this.resendPhoneToken.bind(this);
-    this.handleLogout = this.handleLogout.bind(this);
   }
 
   async componentDidMount() {
@@ -160,13 +159,6 @@ export default class MobilePhoneVerification extends React.Component {
       });
   }
 
-  async handleLogout() {
-    const {orgSlug, logout, cookies, setUserData} = this.props;
-    logout(cookies, orgSlug);
-    setUserData(initialState.userData);
-    toast.success(t`LOGOUT_SUCCESS`);
-  }
-
   async resendPhoneToken() {
     const {setLoading} = this.context;
     setLoading(true);
@@ -176,7 +168,14 @@ export default class MobilePhoneVerification extends React.Component {
 
   render() {
     const {code, errors, success, phone_number} = this.state;
-    const {orgSlug, mobile_phone_verification} = this.props;
+    const {
+      orgSlug,
+      mobile_phone_verification,
+      logout,
+      cookies,
+      setUserData,
+      userData,
+    } = this.props;
     const {input_fields} = mobile_phone_verification;
     return (
       <div className="container content" id="mobile-phone-verification">
@@ -253,7 +252,15 @@ export default class MobilePhoneVerification extends React.Component {
                 <button
                   type="button"
                   className="button full"
-                  onClick={this.handleLogout}
+                  onClick={() =>
+                    handleLogout(
+                      logout,
+                      cookies,
+                      orgSlug,
+                      setUserData,
+                      userData,
+                    )
+                  }
                 >
                   {t`LOGOUT`}
                 </button>

--- a/client/components/mobile-phone-verification/mobile-phone-verification.test.js
+++ b/client/components/mobile-phone-verification/mobile-phone-verification.test.js
@@ -14,11 +14,13 @@ import MobilePhoneVerification from "./mobile-phone-verification";
 import validateToken from "../../utils/validate-token";
 import loadTranslation from "../../utils/load-translation";
 import logError from "../../utils/log-error";
+import handleLogout from "../../utils/handle-logout";
 
 jest.mock("../../utils/get-config");
 jest.mock("../../utils/validate-token");
 jest.mock("../../utils/load-translation");
 jest.mock("../../utils/log-error");
+jest.mock("../../utils/handle-logout");
 jest.mock("axios");
 
 const createTestProps = function (props, configName = "test-org-2") {
@@ -228,7 +230,6 @@ describe("Mobile Phone Token verification: standard flow", () => {
   });
 
   it("should log out successfully", async () => {
-    jest.spyOn(MobilePhoneVerification.prototype, "handleLogout");
     validateToken.mockReturnValue(true);
     jest.spyOn(toast, "success");
 
@@ -237,11 +238,14 @@ describe("Mobile Phone Token verification: standard flow", () => {
 
     wrapper.find(".logout .button").simulate("click");
     await tick();
-    expect(
-      MobilePhoneVerification.prototype.handleLogout.mock.calls.length,
-    ).toBe(1);
-    expect(wrapper.instance().props.logout.mock.calls.length).toBe(1);
-    expect(toast.success.mock.calls.length).toBe(1);
+    expect(handleLogout.mock.calls.length).toBe(1);
+    expect(handleLogout).toHaveBeenCalledWith(
+      props.logout,
+      props.cookies,
+      props.orgSlug,
+      props.setUserData,
+      props.userData,
+    );
   });
 
   it("should set title", async () => {

--- a/client/components/organization-wrapper/organization-wrapper.test.js
+++ b/client/components/organization-wrapper/organization-wrapper.test.js
@@ -528,6 +528,8 @@ describe("Test <OrganizationWrapper /> routes", () => {
       privacy_policy,
       terms_and_conditions,
     };
+    console.error = jest.fn();
+    console.log = jest.fn();
   });
 
   afterEach(() => {

--- a/client/components/password-change/index.js
+++ b/client/components/password-change/index.js
@@ -1,5 +1,5 @@
 import {connect} from "react-redux";
-import {setTitle} from "../../actions/dispatchers";
+import {setTitle, setUserData, logout} from "../../actions/dispatchers";
 
 import Component from "./password-change";
 
@@ -10,11 +10,14 @@ const mapStateToProps = (state, ownProps) => {
     orgSlug: conf.slug,
     orgName: conf.name,
     cookies: ownProps.cookies,
+    userData: conf.userData,
   };
 };
 
 const mapDispatchToProps = (dispatch) => ({
   setTitle: setTitle(dispatch),
+  logout: logout(dispatch),
+  setUserData: setUserData(dispatch),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Component);

--- a/client/components/password-change/password-change.js
+++ b/client/components/password-change/password-change.js
@@ -16,6 +16,7 @@ import LoadingContext from "../../utils/loading-context";
 import logError from "../../utils/log-error";
 import handleChange from "../../utils/handle-change";
 import handleSession from "../../utils/session";
+import validateToken from "../../utils/validate-token";
 
 export default class PasswordChange extends React.Component {
   constructor(props) {
@@ -32,9 +33,11 @@ export default class PasswordChange extends React.Component {
     this.confirmPasswordToggleRef = React.createRef();
   }
 
-  componentDidMount() {
-    const {setTitle, orgName} = this.props;
+  async componentDidMount() {
+    const {setTitle, orgName, cookies, userData, setUserData, logout, orgSlug} =
+      this.props;
     setTitle(t`PWD_CHANGE_TITL`, orgName);
+    await validateToken(cookies, orgSlug, setUserData, userData, logout);
   }
 
   handleSubmit(e) {
@@ -203,4 +206,7 @@ PasswordChange.propTypes = {
     }),
   }).isRequired,
   setTitle: PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired,
+  userData: PropTypes.object.isRequired,
+  setUserData: PropTypes.func.isRequired,
 };

--- a/client/components/password-change/password-change.test.js
+++ b/client/components/password-change/password-change.test.js
@@ -12,11 +12,14 @@ import tick from "../../utils/tick";
 import loadTranslation from "../../utils/load-translation";
 import PasswordChange from "./password-change";
 import PasswordToggleIcon from "../../utils/password-toggle";
+import validateToken from "../../utils/validate-token";
 
 jest.mock("axios");
 jest.mock("../../utils/get-config");
 jest.mock("../../utils/log-error");
 jest.mock("../../utils/load-translation");
+jest.mock("../../utils/validate-token");
+jest.mock("../../utils/handle-logout");
 logError.mockImplementation(jest.fn());
 
 const defaultConfig = getConfig("default", true);
@@ -27,6 +30,9 @@ const createTestProps = (props) => ({
   passwordChange: defaultConfig.components.password_change_form,
   cookies: new Cookies(),
   setTitle: jest.fn(),
+  logout: jest.fn(),
+  userData: {},
+  setUserData: jest.fn(),
   ...props,
 });
 
@@ -194,5 +200,22 @@ describe("<PasswordChange /> interactions", () => {
     });
     nodes.at(1).props().toggler();
     expect(wrapper.instance().state.hidePassword).toEqual(false);
+  });
+  it("should validate token", async () => {
+    props = createTestProps();
+    PasswordChange.contextTypes = {
+      setLoading: PropTypes.func,
+      getLoading: PropTypes.func,
+    };
+    wrapper = await shallow(<PasswordChange {...props} />, {
+      context: {setLoading: jest.fn(), getLoading: jest.fn()},
+    });
+    expect(validateToken).toHaveBeenCalledWith(
+      props.cookies,
+      props.orgSlug,
+      props.setUserData,
+      props.userData,
+      props.logout,
+    );
   });
 });

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -8,13 +8,9 @@ import {t} from "ttag";
 import LoadingContext from "../../utils/loading-context";
 import Contact from "../contact-box";
 import validateToken from "../../utils/validate-token";
+import handleLogout from "../../utils/handle-logout";
 
 export default class PaymentStatus extends React.Component {
-  constructor(props) {
-    super(props);
-    this.handleLogout = this.handleLogout.bind(this);
-  }
-
   async componentDidMount() {
     const {cookies, orgSlug, setUserData, logout, result} = this.props;
     let {userData} = this.props;
@@ -32,13 +28,16 @@ export default class PaymentStatus extends React.Component {
     }
   }
 
-  handleLogout() {
-    const {setUserData, userData} = this.props;
-    setUserData({...userData, mustLogout: true});
-  }
-
   render() {
-    const {orgSlug, result, isAuthenticated, userData} = this.props;
+    const {
+      orgSlug,
+      result,
+      isAuthenticated,
+      userData,
+      logout,
+      setUserData,
+      cookies,
+    } = this.props;
     const {method, is_verified: isVerified} = userData;
     const redirectToStatus = () => <Redirect to={`/${orgSlug}/status`} />;
     const acceptedValues = ["success", "failed"];
@@ -85,7 +84,15 @@ export default class PaymentStatus extends React.Component {
               <div className="row payment-status-row-4">
                 <p>{t`PAY_GIVE_UP_TXT`}</p>
                 <Link
-                  onClick={this.handleLogout}
+                  onClick={() =>
+                    handleLogout(
+                      logout,
+                      cookies,
+                      orgSlug,
+                      setUserData,
+                      userData,
+                    )
+                  }
                   to={`/${orgSlug}/status`}
                   className="button full"
                 >

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -64,6 +64,7 @@ describe("Test <PaymentStatus /> cases", () => {
       setLoading: PropTypes.func,
     };
     console.log = jest.fn();
+    console.error = jest.fn();
     loadTranslation("en", "default");
     validateToken.mockClear();
   });

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -356,7 +356,7 @@ export default class Status extends React.Component {
         localStorage.removeItem(logoutMethodKey);
         return;
       }
-
+      setUserData(initialState.userData);
       setLoading(false);
     }
 

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1207,4 +1207,26 @@ describe("<Status /> interactions", () => {
       value: "4e:ed:11:2b:17:ae",
     });
   });
+  it("should clear userData on logout", async () => {
+    validateToken.mockReturnValue(true);
+    const session = {start_time: "2021-07-08T00:22:28-04:00", stop_time: null};
+    const prop = createTestProps();
+    prop.userData.username = "sankalp";
+    const mockRef = {submit: jest.fn()};
+    wrapper = await shallow(<Status {...prop} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.instance().logoutFormRef = {current: mockRef};
+    wrapper.instance().logoutIframeRef = wrapper.instance().logoutFormRef;
+    wrapper
+      .instance()
+      .setState({sessionsToLogout: [session], activeSession: [session]});
+    await wrapper.instance().handleLogout(false);
+    expect(wrapper.instance().state.loggedOut).toEqual(true);
+    expect(mockRef.submit).toHaveBeenCalled(); // calls handleLogoutIframe
+    await tick();
+    wrapper.instance().handleLogoutIframe();
+    expect(prop.setUserData).toHaveBeenCalledWith(initialState.userData);
+  });
 });

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -12,6 +12,7 @@ import logError from "../../utils/log-error";
 import tick from "../../utils/tick";
 import Status from "./status";
 import validateToken from "../../utils/validate-token";
+import {initialState} from "../../reducers/organization";
 
 jest.mock("axios");
 jest.mock("../../utils/get-config");
@@ -793,7 +794,7 @@ describe("<Status /> interactions", () => {
     expect(status.props.logout).toHaveBeenCalled();
     expect(spyToast.mock.calls.length).toBe(1);
     expect(setLoading.mock.calls).toEqual([[true], [true], [false]]);
-    expect(setUserData).not.toHaveBeenCalled();
+    expect(setUserData).toHaveBeenCalledWith(initialState.userData);
     expect(Status.prototype.getUserActiveRadiusSessions.mock.calls.length).toBe(
       1,
     );

--- a/client/utils/handle-logout.js
+++ b/client/utils/handle-logout.js
@@ -1,0 +1,29 @@
+import {toast} from "react-toastify";
+import {t} from "ttag";
+import {initialState} from "../reducers/organization";
+
+const redirectToStatus = (setUserData, userData, orgSlug) => {
+  setUserData({...userData, mustLogout: true});
+  window.location.assign(`${window.location.origin}/${orgSlug}/status`);
+};
+
+const handleLogout = (logout, cookies, orgSlug, setUserData, userData) => {
+  /*
+   * Redirecting to the status page for captive-portal logout if the
+   * method is unspecified or bank_card or the user is verified.
+   */
+  if (
+    userData.is_active === true &&
+    (userData.method === "" ||
+      userData.method === "bank_card" ||
+      userData.is_verified === true)
+  ) {
+    redirectToStatus(setUserData, userData, orgSlug);
+    return;
+  }
+  logout(cookies, orgSlug);
+  toast.error(t`ERR_OCCUR`);
+  setUserData(initialState.userData);
+};
+
+export default handleLogout;

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -169,16 +169,22 @@ describe("Validate Token tests", () => {
     orgSlug: "default",
     cookies: new Cookies(),
     setUserData: jest.fn(),
-    userData: {is_active: true, is_verified: true},
+    userData: {is_active: true, is_verified: null, justAuthenticated: true},
     logout: jest.fn(),
   });
   it("should return false if token is not in the cookie", async () => {
     const {orgSlug, cookies, setUserData, userData, logout} = getArgs();
-    const result = await validateToken(cookies, orgSlug, setUserData, userData);
+    const result = await validateToken(
+      cookies,
+      orgSlug,
+      setUserData,
+      userData,
+      logout,
+    );
     expect(axios.mock.calls.length).toBe(0);
     expect(result).toBe(false);
-    expect(setUserData.mock.calls.length).toBe(0);
-    expect(logout.mock.calls.length).toBe(0);
+    expect(setUserData.mock.calls.length).toBe(1);
+    expect(logout.mock.calls.length).toBe(1);
   });
   it("should return true for success validation", async () => {
     axios.mockImplementationOnce(() =>
@@ -197,7 +203,13 @@ describe("Validate Token tests", () => {
     );
     const {orgSlug, cookies, setUserData, userData, logout} = getArgs();
     cookies.set(`${orgSlug}_auth_token`, "token");
-    const result = await validateToken(cookies, orgSlug, setUserData, userData);
+    const result = await validateToken(
+      cookies,
+      orgSlug,
+      setUserData,
+      userData,
+      logout,
+    );
     expect(axios).toHaveBeenCalled();
     expect(setUserData.mock.calls.length).toBe(1);
     expect(result).toBe(true);
@@ -206,7 +218,13 @@ describe("Validate Token tests", () => {
   it("should return true without calling api if radius token is present", async () => {
     const {orgSlug, cookies, setUserData, userData, logout} = getArgs();
     userData.radius_user_token = "token";
-    const result = await validateToken(cookies, orgSlug, setUserData, userData);
+    const result = await validateToken(
+      cookies,
+      orgSlug,
+      setUserData,
+      userData,
+      logout,
+    );
     expect(axios.mock.calls.length).toBe(0);
     expect(result).toBe(true);
     expect(setUserData.mock.calls.length).toBe(0);

--- a/client/utils/validate-token.js
+++ b/client/utils/validate-token.js
@@ -1,18 +1,10 @@
 import qs from "qs";
 import axios from "axios";
-import {toast} from "react-toastify";
 import {t} from "ttag";
 import {validateApiUrl} from "../constants";
 import handleSession from "./session";
 import logError from "./log-error";
-import {initialState} from "../reducers/organization";
-
-const handleLogout = (logout, cookies, orgSlug, setUserData) => {
-  logout(cookies, orgSlug);
-  toast.error(t`ERR_OCCUR`);
-  const {userData} = initialState;
-  setUserData(userData);
-};
+import handleLogout from "./handle-logout";
 
 const validateToken = async (
   cookies,
@@ -39,7 +31,7 @@ const validateToken = async (
         }),
       });
       if (response.data.response_code !== "AUTH_TOKEN_VALIDATION_SUCCESSFUL") {
-        handleLogout(logout, cookies, orgSlug, setUserData);
+        handleLogout(logout, cookies, orgSlug, setUserData, userData);
         logError(
           response,
           '"response_code" !== "AUTH_TOKEN_VALIDATION_SUCCESSFUL"',
@@ -49,7 +41,7 @@ const validateToken = async (
       setUserData(response.data);
       return true;
     } catch (error) {
-      handleLogout(logout, cookies, orgSlug, setUserData);
+      handleLogout(logout, cookies, orgSlug, setUserData, userData);
       logError(error, t`ERR_OCCUR`);
       return false;
     }
@@ -60,6 +52,7 @@ const validateToken = async (
   }
   // returns false if token is invalid or user data is empty
   else {
+    handleLogout(logout, cookies, orgSlug, setUserData, userData);
     return false;
   }
 };


### PR DESCRIPTION
If the session is active then setUserData is not called after captive
portal logout. Added setUserData with initialData.userData after
performing captive portal logout.

Fixes #343
Closes #306 