### PR TITLE
[misc] Disable components for unrelated registration methods, add ways to avoid showing links to specific methods, changed "method" to "methods_only"

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,17 +276,20 @@ yarn stats
 #### Menu items
 
 By default, menu items are visible to any user, but it's possible to
-configure some items to be visible only to authenticated users or
-to unauthenticated users by specifying the `authenticated`, `verified`, `methods`
-and `methods_excluded` property.
+configure some items to be visible only to authenticated users,
+unauthenticated users, verified users, unverified users or
+users registered with specific registration methods by
+specifying the `authenticated`, `verified`, `methods_only`
+and `methods_excluded` properties.
 
 - `authenticated: true` means visible only to authenticated users.
 - `authenticated: false` means visible only to unauthenticated users.
 - `verified: true` means visible to authenticated and verified users.
 - `verified: false` means visible to only authenticated and unverified users.
-- `methods: ["mobile_phone"]` means visible to mobile phone registration enabled organization users.
-- `methods_excluded: ["saml", "social_login"]` means not visible to user with
-  methods SAML and social login.
+- `methods_only: ["mobile_phone"]` means visible only to users registered
+  with mobile phone verification.
+- `methods_excluded: ["saml", "social_login"]` means not visible to users
+  which sign in using SAML and social login.
 - unspecified: link will be visible to any user (default behavior)
 
 Let us consider the following configuration for the header, footer and contact components:
@@ -316,7 +319,7 @@ components:
           en: "change phone number"
         url: "/mobile/change-phone-number"
         authenticated: true
-        methods:
+        methods_only:
           - mobile_phone
   footer:
     links:
@@ -345,6 +348,17 @@ With the configuration above:
 - `sign up` (from Header) link will be visible to only unauthenticated users.
 - the link to `twitter` (from Contact) and `change password` (from Header)
   links will be visible to only authenticated users
+- change password will not be visible to users which sign in with
+  social login or signle sign-on (SAML)
+- change mobile phone number will only be visible to users which have
+  signed up with mobile phone verification
+
+**Notes**:
+
+- `methods_only` and `methods_excluded` only make sense for links which
+  are visible to authenticated users
+- using both `methods_excluded` and `methods_only` on the same link does
+  not make sense
 
 #### User Fields in Registration Form
 

--- a/README.md
+++ b/README.md
@@ -277,14 +277,16 @@ yarn stats
 
 By default, menu items are visible to any user, but it's possible to
 configure some items to be visible only to authenticated users or
-to unauthenticated users by specifying the `authenticated`, `verified`
-and `method` property.
+to unauthenticated users by specifying the `authenticated`, `verified`, `methods`
+and `methods_excluded` property.
 
 - `authenticated: true` means visible only to authenticated users.
 - `authenticated: false` means visible only to unauthenticated users.
 - `verified: true` means visible to authenticated and verified users.
 - `verified: false` means visible to only authenticated and unverified users.
-- `method: "mobile_phone"` means visible to mobile phone registration enabled organization users.
+- `methods: ["mobile_phone"]` means visible to mobile phone registration enabled organization users.
+- `methods_excluded: ["saml", "social_login"]` means not visible to user with
+  methods SAML and social login.
 - unspecified: link will be visible to any user (default behavior)
 
 Let us consider the following configuration for the header, footer and contact components:
@@ -306,12 +308,16 @@ components:
         authenticated: true
         # if organization supports any verification method
         verified: true
+        methods_excluded:
+          - saml
+          - social_login
       # if organization supports mobile verification
       - text:
           en: "change phone number"
         url: "/mobile/change-phone-number"
         authenticated: true
-        method: "mobile_phone"
+        methods:
+          - mobile_phone
   footer:
     links:
       - text:

--- a/client/components/header/header.js
+++ b/client/components/header/header.js
@@ -126,9 +126,7 @@ export default class Header extends React.Component {
           <div className="header-row-2">
             <div className="header-row-2-inner">
               {links.map((link, index) => {
-                if (
-                  !shouldLinkBeShown(link, isAuthenticated, userData, orgSlug)
-                ) {
+                if (!shouldLinkBeShown(link, isAuthenticated, userData)) {
                   return null;
                 }
                 if (
@@ -212,7 +210,7 @@ export default class Header extends React.Component {
             } header-mobile-menu`}
           >
             {links.map((link, index) => {
-              if (shouldLinkBeShown(link, isAuthenticated, userData, orgSlug)) {
+              if (shouldLinkBeShown(link, isAuthenticated, userData)) {
                 if (isInternalLink(link.url)) {
                   return (
                     <Link

--- a/client/components/header/header.js
+++ b/client/components/header/header.js
@@ -126,7 +126,9 @@ export default class Header extends React.Component {
           <div className="header-row-2">
             <div className="header-row-2-inner">
               {links.map((link, index) => {
-                if (!shouldLinkBeShown(link, isAuthenticated, userData)) {
+                if (
+                  !shouldLinkBeShown(link, isAuthenticated, userData, orgSlug)
+                ) {
                   return null;
                 }
                 if (
@@ -210,7 +212,7 @@ export default class Header extends React.Component {
             } header-mobile-menu`}
           >
             {links.map((link, index) => {
-              if (shouldLinkBeShown(link, isAuthenticated, userData)) {
+              if (shouldLinkBeShown(link, isAuthenticated, userData, orgSlug)) {
                 if (isInternalLink(link.url)) {
                   return (
                     <Link

--- a/client/components/header/header.test.js
+++ b/client/components/header/header.test.js
@@ -211,6 +211,20 @@ describe("<Header /> rendering", () => {
     expect(wrapper.find(".sticky-msg").length).toEqual(0);
     expect(wrapper.find(".close-sticky-btn").length).toEqual(0);
   });
+  it("should not show change password if login method is SAML / Social Login", () => {
+    props = createTestProps();
+    props.header.links = [
+      {
+        text: {en: "Change Password"},
+        url: "/{orgSlug}/change-password",
+        authenticated: false,
+      },
+    ];
+    localStorage.setItem(`${props.orgSlug}_logout_method`, "saml");
+    wrapper = shallow(<Header {...props} />);
+    const linkText = getLinkText(wrapper, ".header-link");
+    expect(linkText).not.toContain("Change Password");
+  });
 });
 
 describe("<Header /> interactions", () => {

--- a/client/components/header/header.test.js
+++ b/client/components/header/header.test.js
@@ -217,13 +217,21 @@ describe("<Header /> rendering", () => {
       {
         text: {en: "Change Password"},
         url: "/{orgSlug}/change-password",
-        authenticated: false,
+        authenticated: true,
+        methods_excluded: ["saml", "social_login"],
       },
     ];
-    localStorage.setItem(`${props.orgSlug}_logout_method`, "saml");
+    props.isAuthenticated = true;
+    props.userData.method = "saml";
     wrapper = shallow(<Header {...props} />);
-    const linkText = getLinkText(wrapper, ".header-link");
+    let linkText = getLinkText(wrapper, ".header-link");
     expect(linkText).not.toContain("Change Password");
+    wrapper.setProps({userData: {...props.userData, method: "social_login"}});
+    linkText = getLinkText(wrapper, ".header-link");
+    expect(linkText).not.toContain("Change Password");
+    wrapper.setProps({userData: {...props.userData, method: "mobile_phone"}});
+    linkText = getLinkText(wrapper, ".header-link");
+    expect(linkText).toContain("Change Password");
   });
 });
 

--- a/client/components/mobile-phone-change/mobile-phone-change.js
+++ b/client/components/mobile-phone-change/mobile-phone-change.js
@@ -112,11 +112,15 @@ class MobilePhoneChange extends React.Component {
 
   render() {
     const {phone_number, errors} = this.state;
-    const {orgSlug, phone_number_change, settings} = this.props;
+    const {orgSlug, phone_number_change, settings, userData} = this.props;
     const {input_fields} = phone_number_change;
 
     // check equality to false, it may be undefined
-    if (!settings.mobile_phone_verification) {
+    if (
+      !settings.mobile_phone_verification &&
+      userData.method !== undefined &&
+      userData.method !== "mobile_phone"
+    ) {
       return <Redirect to={`/${orgSlug}/status`} />;
     }
 

--- a/client/components/mobile-phone-change/mobile-phone-change.js
+++ b/client/components/mobile-phone-change/mobile-phone-change.js
@@ -115,13 +115,11 @@ class MobilePhoneChange extends React.Component {
     const {orgSlug, phone_number_change, settings, userData} = this.props;
     const {input_fields} = phone_number_change;
 
-    // check equality to false, it may be undefined
     if (
-      !settings.mobile_phone_verification &&
-      userData.method !== undefined &&
-      userData.method !== "mobile_phone"
+      !settings.mobile_phone_verification ||
+      (userData.method !== undefined && userData.method !== "mobile_phone")
     ) {
-      return <Redirect to={`/${orgSlug}/status`} />;
+      return <Redirect push to={`/${orgSlug}/status`} />;
     }
 
     return (

--- a/client/components/mobile-phone-change/mobile-phone-change.test.js
+++ b/client/components/mobile-phone-change/mobile-phone-change.test.js
@@ -382,7 +382,7 @@ describe("Change Phone Number: corner cases", () => {
     expect(setUserData.mock.calls.length).toBe(0);
   });
 
-  it("should redirect only if mobile_phone_verification is disabled", async () => {
+  it("should not redirect only if mobile_phone_verification is enabled", async () => {
     mockAxios();
     props.settings.mobile_phone_verification = true;
     wrapper = await mountComponent(props);
@@ -391,6 +391,7 @@ describe("Change Phone Number: corner cases", () => {
 
   it("should redirect if mobile_phone_verification disabled", async () => {
     props.settings.mobile_phone_verification = false;
+    props.userData = {is_active: true, method: "saml"};
     wrapper = await mountComponent(props);
     expect(wrapper.find(Redirect)).toHaveLength(1);
   });
@@ -398,6 +399,16 @@ describe("Change Phone Number: corner cases", () => {
   it("shouldn't redirect if user is active and mobile verificaton is true", async () => {
     validateToken.mockReturnValue(true);
     userData.is_active = true;
+    props.userData = userData;
+    props.settings.mobile_phone_verification = true;
+    wrapper = await mountComponent(props);
+    expect(wrapper.find(Redirect)).toHaveLength(0);
+  });
+
+  it("should not redirect if user registration method is mobile_phone", async () => {
+    validateToken.mockReturnValue(true);
+    props.userData.is_active = true;
+    props.userData.method = "saml";
     props.userData = userData;
     props.settings.mobile_phone_verification = true;
     wrapper = await mountComponent(props);

--- a/client/components/mobile-phone-change/mobile-phone-change.test.js
+++ b/client/components/mobile-phone-change/mobile-phone-change.test.js
@@ -382,7 +382,7 @@ describe("Change Phone Number: corner cases", () => {
     expect(setUserData.mock.calls.length).toBe(0);
   });
 
-  it("should not redirect only if mobile_phone_verification is enabled", async () => {
+  it("should not redirect if mobile_phone_verification is enabled", async () => {
     mockAxios();
     props.settings.mobile_phone_verification = true;
     wrapper = await mountComponent(props);
@@ -391,7 +391,6 @@ describe("Change Phone Number: corner cases", () => {
 
   it("should redirect if mobile_phone_verification disabled", async () => {
     props.settings.mobile_phone_verification = false;
-    props.userData = {is_active: true, method: "saml"};
     wrapper = await mountComponent(props);
     expect(wrapper.find(Redirect)).toHaveLength(1);
   });
@@ -407,12 +406,22 @@ describe("Change Phone Number: corner cases", () => {
 
   it("should not redirect if user registration method is mobile_phone", async () => {
     validateToken.mockReturnValue(true);
-    props.userData.is_active = true;
-    props.userData.method = "saml";
     props.userData = userData;
+    props.userData.is_active = true;
+    props.userData.method = "mobile_phone";
     props.settings.mobile_phone_verification = true;
     wrapper = await mountComponent(props);
     expect(wrapper.find(Redirect)).toHaveLength(0);
+  });
+
+  it("should redirect if user registration method is not mobile_phone", async () => {
+    validateToken.mockReturnValue(true);
+    props.userData = userData;
+    props.userData.is_active = true;
+    props.userData.method = "saml";
+    props.settings.mobile_phone_verification = true;
+    wrapper = await mountComponent(props);
+    expect(wrapper.find(Redirect)).toHaveLength(1);
   });
 
   it("should validate token", async () => {

--- a/client/components/password-change/password-change.js
+++ b/client/components/password-change/password-change.js
@@ -98,10 +98,13 @@ export default class PasswordChange extends React.Component {
   }
 
   render() {
-    const {passwordChange, orgSlug} = this.props;
+    const {passwordChange, orgSlug, userData} = this.props;
     const {errors, newPassword1, newPassword2, hidePassword} = this.state;
-    const logoutMethod = localStorage.getItem(`${orgSlug}_logout_method`);
-    if (logoutMethod) return <Redirect to={`/${orgSlug}/status`} />;
+    if (
+      userData &&
+      (userData.method === "saml" || userData.method === "social_login")
+    )
+      return <Redirect to={`/${orgSlug}/status`} />;
     return (
       <div className="container content" id="password-change">
         <div className="inner">

--- a/client/components/password-change/password-change.js
+++ b/client/components/password-change/password-change.js
@@ -100,10 +100,7 @@ export default class PasswordChange extends React.Component {
   render() {
     const {passwordChange, orgSlug, userData} = this.props;
     const {errors, newPassword1, newPassword2, hidePassword} = this.state;
-    if (
-      userData &&
-      (userData.method === "saml" || userData.method === "social_login")
-    )
+    if (userData && ["saml", "social_login"].includes(userData.method))
       return <Redirect to={`/${orgSlug}/status`} />;
     return (
       <div className="container content" id="password-change">

--- a/client/components/password-change/password-change.js
+++ b/client/components/password-change/password-change.js
@@ -7,6 +7,7 @@ import React from "react";
 import {toast} from "react-toastify";
 import {Cookies} from "react-cookie";
 import {t} from "ttag";
+import {Redirect} from "react-router-dom";
 import PasswordToggleIcon from "../../utils/password-toggle";
 import {passwordChangeApiUrl} from "../../constants";
 import getErrorText from "../../utils/get-error-text";
@@ -97,8 +98,10 @@ export default class PasswordChange extends React.Component {
   }
 
   render() {
-    const {passwordChange} = this.props;
+    const {passwordChange, orgSlug} = this.props;
     const {errors, newPassword1, newPassword2, hidePassword} = this.state;
+    const logoutMethod = localStorage.getItem(`${orgSlug}_logout_method`);
+    if (logoutMethod) return <Redirect to={`/${orgSlug}/status`} />;
     return (
       <div className="container content" id="password-change">
         <div className="inner">

--- a/client/components/password-change/password-change.test.js
+++ b/client/components/password-change/password-change.test.js
@@ -225,12 +225,14 @@ describe("<PasswordChange /> interactions", () => {
       setLoading: PropTypes.func,
       getLoading: PropTypes.func,
     };
-    localStorage.setItem(`${props.orgSlug}_logout_method`, "saml");
+    props.userData.method = "saml";
     wrapper = await shallow(<PasswordChange {...props} />, {
       context: {setLoading: jest.fn(), getLoading: jest.fn()},
     });
     expect(wrapper.find("Redirect").length).toEqual(1);
     expect(wrapper.find("Redirect").props().to).toEqual("/default/status");
-    localStorage.removeItem(`${props.orgSlug}_logout_method`);
+    await wrapper.setProps({...props.userData, method: "social_login"});
+    expect(wrapper.find("Redirect").length).toEqual(1);
+    expect(wrapper.find("Redirect").props().to).toEqual("/default/status");
   });
 });

--- a/client/components/password-change/password-change.test.js
+++ b/client/components/password-change/password-change.test.js
@@ -219,4 +219,18 @@ describe("<PasswordChange /> interactions", () => {
       props.logout,
     );
   });
+  it("should redirect to status if login method is SAML / Social Login", async () => {
+    props = createTestProps();
+    PasswordChange.contextTypes = {
+      setLoading: PropTypes.func,
+      getLoading: PropTypes.func,
+    };
+    localStorage.setItem(`${props.orgSlug}_logout_method`, "saml");
+    wrapper = await shallow(<PasswordChange {...props} />, {
+      context: {setLoading: jest.fn(), getLoading: jest.fn()},
+    });
+    expect(wrapper.find("Redirect").length).toEqual(1);
+    expect(wrapper.find("Redirect").props().to).toEqual("/default/status");
+    localStorage.removeItem(`${props.orgSlug}_logout_method`);
+  });
 });

--- a/client/utils/should-link-be-shown.js
+++ b/client/utils/should-link-be-shown.js
@@ -1,5 +1,7 @@
 /* eslint-disable camelcase */
-const shouldLinkBeShown = (link, isAuthenticated, userData) => {
+const shouldLinkBeShown = (link, isAuthenticated, userData, orgSlug = null) => {
+  const logoutMethod = localStorage.getItem(`${orgSlug}_logout_method`);
+  if (logoutMethod && link.url === "/{orgSlug}/change-password") return false;
   const {is_verified} = userData;
   if (
     link.authenticated === isAuthenticated &&

--- a/client/utils/should-link-be-shown.js
+++ b/client/utils/should-link-be-shown.js
@@ -1,8 +1,13 @@
 /* eslint-disable camelcase */
-const shouldLinkBeShown = (link, isAuthenticated, userData, orgSlug = null) => {
-  const logoutMethod = localStorage.getItem(`${orgSlug}_logout_method`);
-  if (logoutMethod && link.url === "/{orgSlug}/change-password") return false;
-  const {is_verified} = userData;
+const shouldLinkBeShown = (link, isAuthenticated, userData) => {
+  const {is_verified, method} = userData;
+  if (
+    method &&
+    link.methods_excluded &&
+    link.methods_excluded.includes(method)
+  ) {
+    return false;
+  }
   if (
     link.authenticated === isAuthenticated &&
     isAuthenticated === true &&
@@ -14,9 +19,9 @@ const shouldLinkBeShown = (link, isAuthenticated, userData, orgSlug = null) => {
   if (
     link.authenticated === isAuthenticated &&
     isAuthenticated === true &&
-    link.method !== undefined
+    link.methods !== undefined
   ) {
-    return link.method === userData.method;
+    return link.methods.includes(userData.method);
   }
   return (
     link.authenticated === undefined || link.authenticated === isAuthenticated

--- a/client/utils/should-link-be-shown.js
+++ b/client/utils/should-link-be-shown.js
@@ -19,9 +19,9 @@ const shouldLinkBeShown = (link, isAuthenticated, userData) => {
   if (
     link.authenticated === isAuthenticated &&
     isAuthenticated === true &&
-    link.methods !== undefined
+    link.methods_only !== undefined
   ) {
-    return link.methods.includes(userData.method);
+    return link.methods_only.includes(userData.method);
   }
   return (
     link.authenticated === undefined || link.authenticated === isAuthenticated

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -134,21 +134,29 @@ describe("shouldLinkBeShown tests", () => {
     );
     expect(shouldLinkBeShown(link, isAuthenticated, userData)).toBe(false);
   });
-  it("should return false if user is authenticated and link.method is not equal to userData.method", () => {
+  it("should return false if user is authenticated and userData.method is not in link.methods", () => {
     const {link, isAuthenticated, userData} = createArgs(
-      {authenticated: true, method: "payment"},
+      {authenticated: true, methods: ["payment"]},
       true,
       {method: "mobile_phone"},
     );
     expect(shouldLinkBeShown(link, isAuthenticated, userData)).toBe(false);
   });
-  it("should return true if userData.method and link.method is same", () => {
+  it("should return true if userData.method is in link.methods", () => {
     const {link, isAuthenticated, userData} = createArgs(
-      {authenticated: true, method: "payment"},
+      {authenticated: true, methods: ["payment"]},
       true,
       {method: "payment"},
     );
     expect(shouldLinkBeShown(link, isAuthenticated, userData)).toBe(true);
+  });
+  it("should return false if userData.method is in link.methods_excluded", () => {
+    const {link, isAuthenticated, userData} = createArgs(
+      {authenticated: true, methods_excluded: ["payment"]},
+      true,
+      {method: "payment"},
+    );
+    expect(shouldLinkBeShown(link, isAuthenticated, userData)).toBe(false);
   });
 });
 describe("tick tests", () => {

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -134,17 +134,17 @@ describe("shouldLinkBeShown tests", () => {
     );
     expect(shouldLinkBeShown(link, isAuthenticated, userData)).toBe(false);
   });
-  it("should return false if user is authenticated and userData.method is not in link.methods", () => {
+  it("should return false if user is authenticated and userData.method is not in link.methods_only", () => {
     const {link, isAuthenticated, userData} = createArgs(
-      {authenticated: true, methods: ["payment"]},
+      {authenticated: true, methods_only: ["payment"]},
       true,
       {method: "mobile_phone"},
     );
     expect(shouldLinkBeShown(link, isAuthenticated, userData)).toBe(false);
   });
-  it("should return true if userData.method is in link.methods", () => {
+  it("should return true if userData.method is in link.methods_only", () => {
     const {link, isAuthenticated, userData} = createArgs(
-      {authenticated: true, methods: ["payment"]},
+      {authenticated: true, methods_only: ["payment"]},
       true,
       {method: "payment"},
     );

--- a/internals/generators/organization/config.yml.hbs
+++ b/internals/generators/organization/config.yml.hbs
@@ -68,12 +68,16 @@ client:
           {{#if mobile_phone_verification }}
           verified: true
           {{/if}}
+          methods_excluded:
+            - saml
+            - social_login
       {{#if mobile_phone_verification }}
         - text:
             en: "Change phone number"
           url: "/{orgSlug}/change-phone-number"
           authenticated: true
-          method: "mobile_phone"
+          methods:
+            - mobile_phone
       {{/if}}
 
     footer:

--- a/organizations/default.yml
+++ b/organizations/default.yml
@@ -49,6 +49,9 @@ client:
             en: "Change password"
           url: "/{orgSlug}/change-password"
           authenticated: true
+          methods_excluded:
+            - saml
+            - social_login
 
     footer:
       links:


### PR DESCRIPTION
Disabled password-change Component for social login and SAML.
Disabled phone-number change for method other than mobile_phone.
Support for methods and methods_excluded for links.

Closes #338
Closes #339 
Closes #368 