### PR TITLE
[fix] Fixed PhoneInput loading glitch #373

### DIFF
--- a/client/components/registration/__snapshots__/registration.test.js.snap
+++ b/client/components/registration/__snapshots__/registration.test.js.snap
@@ -334,6 +334,7 @@ exports[`Registration and Mobile Phone Verification interactions should render P
 <Suspense
   fallback={
     <input
+      className="input"
       name="phone_number"
       onChange={[Function]}
       onKeyDown={[Function]}

--- a/client/components/registration/registration.js
+++ b/client/components/registration/registration.js
@@ -386,6 +386,7 @@ export default class Registration extends React.Component {
                               fallback={
                                 <input
                                   type="tel"
+                                  className="input"
                                   name="phone_number"
                                   value={phone_number}
                                   onChange={(value) =>

--- a/client/components/registration/registration.test.js
+++ b/client/components/registration/registration.test.js
@@ -431,6 +431,7 @@ describe("Registration and Mobile Phone Verification interactions", () => {
     expect(fallback.type).toEqual("input");
     expect(fallback.props).toEqual({
       name: "phone_number",
+      className: "input",
       value: "",
       onChange: expect.any(Function),
       onKeyDown: expect.any(Function),


### PR DESCRIPTION
If the CSS class is assigned to the fallback suspense element, the difference with PhoneInput is not noticeable and this should be good enough.

Fixes #373