### PR TITLE
[misc] Simplified loader styles and other minor aspects

### DIFF
--- a/client/components/modal/index.css
+++ b/client/components/modal/index.css
@@ -1,7 +1,6 @@
 .w-900 {
   max-width: 900px;
 }
-
 .text-left {
   text-align: left;
 }
@@ -12,16 +11,13 @@
   text-decoration: none;
   color: inherit;
 }
-
 .modal-container .message h1 {
   text-align: center;
 }
-
 .message {
   max-height: 70vh;
   overflow: auto;
 }
-
 .modal-container .message h1 {
   font-size: 21px;
 }
@@ -30,9 +26,4 @@
 }
 .modal-container .message {
   line-height: 30px;
-}
-.load-container {
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
 }

--- a/client/components/modal/modal.js
+++ b/client/components/modal/modal.js
@@ -8,6 +8,7 @@ import axios from "axios";
 import getText from "../../utils/get-text";
 import {modalContentUrl} from "../../constants";
 import logError from "../../utils/log-error";
+import Loader from "../../utils/loader";
 import getLanguageHeaders from "../../utils/get-language-headers";
 
 export default class Modal extends React.Component {
@@ -80,9 +81,7 @@ export default class Modal extends React.Component {
               &#10006;
             </Link>
             {loading ? (
-              <div className="load-container">
-                <div className="loader" />
-              </div>
+              <Loader full={false} />
             ) : (
               <div
                 className="message"

--- a/client/components/organization-wrapper/index.css
+++ b/client/components/organization-wrapper/index.css
@@ -14,29 +14,6 @@
 .middle {
   flex-grow: 1;
 }
-.loader-container {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-}
-.full-page-loader-container {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  flex-direction: row;
-  justify-content: center;
-  align-items: center;
-  background: rgba(255, 255, 255, 1);
-}
 .org-wrapper-not-found {
   display: flex;
   flex-direction: column;

--- a/client/components/organization-wrapper/organization-wrapper.js
+++ b/client/components/organization-wrapper/organization-wrapper.js
@@ -323,9 +323,6 @@ export default class OrganizationWrapper extends React.Component {
               <DoesNotExist />
             </Suspense>
           </div>
-          <Helmet>
-            <title>Page not found</title>
-          </Helmet>
         </>
       );
     }

--- a/client/components/organization-wrapper/organization-wrapper.js
+++ b/client/components/organization-wrapper/organization-wrapper.js
@@ -142,7 +142,7 @@ export default class OrganizationWrapper extends React.Component {
                       );
                     }
                     return (
-                      <Suspense fallback={<Loader full={false} />}>
+                      <Suspense fallback={<Loader />}>
                         <Registration {...props} />
                       </Suspense>
                     );
@@ -162,7 +162,7 @@ export default class OrganizationWrapper extends React.Component {
                       return <Redirect to={`/${orgSlug}/login`} />;
                     }
                     return (
-                      <Suspense fallback={<Loader full={false} />}>
+                      <Suspense fallback={<Loader />}>
                         <MobilePhoneVerification {...props} cookies={cookies} />
                       </Suspense>
                     );
@@ -174,7 +174,7 @@ export default class OrganizationWrapper extends React.Component {
                     if (isAuthenticated)
                       return <Redirect to={`/${orgSlug}/status`} />;
                     return (
-                      <Suspense fallback={<Loader full={false} />}>
+                      <Suspense fallback={<Loader />}>
                         <PasswordConfirm {...props} />
                       </Suspense>
                     );
@@ -187,7 +187,7 @@ export default class OrganizationWrapper extends React.Component {
                     if (isAuthenticated)
                       return <Redirect to={`/${orgSlug}/status`} />;
                     return (
-                      <Suspense fallback={<Loader full={false} />}>
+                      <Suspense fallback={<Loader />}>
                         <PasswordReset />
                       </Suspense>
                     );
@@ -199,7 +199,7 @@ export default class OrganizationWrapper extends React.Component {
                     if (isAuthenticated && is_active)
                       return <Redirect to={`/${orgSlug}/status`} />;
                     return (
-                      <Suspense fallback={<Loader full={false} />}>
+                      <Suspense fallback={<Loader />}>
                         <Login {...props} />
                       </Suspense>
                     );
@@ -216,7 +216,7 @@ export default class OrganizationWrapper extends React.Component {
                       );
                     if (isAuthenticated) {
                       return (
-                        <Suspense fallback={<Loader full={false} />}>
+                        <Suspense fallback={<Loader />}>
                           <Status {...props} cookies={cookies} />
                         </Suspense>
                       );
@@ -233,7 +233,7 @@ export default class OrganizationWrapper extends React.Component {
                       return <Redirect to={`/${orgSlug}/status`} />;
                     if (userAutoLogin)
                       return (
-                        <Suspense fallback={<Loader full={false} />}>
+                        <Suspense fallback={<Loader />}>
                           <Logout {...props} />
                         </Suspense>
                       );
@@ -245,7 +245,7 @@ export default class OrganizationWrapper extends React.Component {
                   render={() => {
                     if (isAuthenticated)
                       return (
-                        <Suspense fallback={<Loader full={false} />}>
+                        <Suspense fallback={<Loader />}>
                           <PasswordChange cookies={cookies} />
                         </Suspense>
                       );
@@ -257,7 +257,7 @@ export default class OrganizationWrapper extends React.Component {
                   render={() => {
                     if (isAuthenticated)
                       return (
-                        <Suspense fallback={<Loader full={false} />}>
+                        <Suspense fallback={<Loader />}>
                           <MobilePhoneChange cookies={cookies} />
                         </Suspense>
                       );
@@ -269,7 +269,7 @@ export default class OrganizationWrapper extends React.Component {
                   render={(props) => {
                     const {result} = props.match.params;
                     return (
-                      <Suspense fallback={<Loader full={false} />}>
+                      <Suspense fallback={<Loader />}>
                         <PaymentStatus cookies={cookies} result={result} />
                       </Suspense>
                     );
@@ -277,7 +277,7 @@ export default class OrganizationWrapper extends React.Component {
                 />
                 <Route
                   render={() => (
-                    <Suspense fallback={<Loader full={false} />}>
+                    <Suspense fallback={<Loader />}>
                       <ConnectedDoesNotExist />
                     </Suspense>
                   )}
@@ -306,11 +306,7 @@ export default class OrganizationWrapper extends React.Component {
                 />
               </Helmet>
             ) : null}
-            {loading && (
-              <div className="loader-container">
-                <div className="loader" />
-              </div>
-            )}
+            {loading && <Loader />}
           </LoadingContext.Provider>
         </>
       ) : null;
@@ -319,18 +315,14 @@ export default class OrganizationWrapper extends React.Component {
       return (
         <>
           <div className="org-wrapper-not-found">
-            <Suspense fallback={<Loader full={false} />}>
+            <Suspense fallback={<Loader />}>
               <DoesNotExist />
             </Suspense>
           </div>
         </>
       );
     }
-    return (
-      <div className="loader-container">
-        <div className="loader" />
-      </div>
-    );
+    return <Loader />;
   }
 }
 OrganizationWrapper.defaultProps = {

--- a/client/components/organization-wrapper/organization-wrapper.test.js
+++ b/client/components/organization-wrapper/organization-wrapper.test.js
@@ -85,7 +85,7 @@ describe("<OrganizationWrapper /> rendering", () => {
     });
     expect(wrapper.find(".app-container")).toHaveLength(0);
     expect(wrapper.find(".org-wrapper-not-found")).toHaveLength(0);
-    expect(wrapper.find(".loader-container")).toHaveLength(1);
+    expect(wrapper.find(Loader)).toHaveLength(1);
   });
 
   it("should render correctly when organization doesn't exist", () => {
@@ -241,7 +241,7 @@ describe("<OrganizationWrapper /> interactions", () => {
     const cookies = new Cookies();
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <Status cookies={cookies} />
         </Suspense>,
       ),
@@ -251,7 +251,7 @@ describe("<OrganizationWrapper /> interactions", () => {
     render = pathMap["/default/change-password"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <PasswordChange cookies={cookies} />
         </Suspense>,
       ),
@@ -259,7 +259,7 @@ describe("<OrganizationWrapper /> interactions", () => {
     render = pathMap["/default/change-phone-number"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <MobilePhoneChange cookies={cookies} />
         </Suspense>,
       ),
@@ -267,7 +267,7 @@ describe("<OrganizationWrapper /> interactions", () => {
     render = pathMap["/default/payment/:result"];
     expect(JSON.stringify(render(createTestProps()))).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <PaymentStatus cookies={cookies} />
         </Suspense>,
       ),
@@ -275,7 +275,7 @@ describe("<OrganizationWrapper /> interactions", () => {
     render = pathMap.notFound;
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <ConnectedDoesNotExist />
         </Suspense>,
       ),
@@ -322,7 +322,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
     render = pathMap["/default/registration"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <Registration />
         </Suspense>,
       ),
@@ -332,7 +332,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
     render = pathMap["/default/password/reset/confirm/:uid/:token"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <PasswordConfirm />
         </Suspense>,
       ),
@@ -340,7 +340,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
     render = pathMap["/default/password/reset"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <PasswordReset />
         </Suspense>,
       ),
@@ -348,7 +348,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
     render = pathMap["/default/login"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <Login />
         </Suspense>,
       ),
@@ -359,7 +359,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
     render = pathMap["/default/logout"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <Logout />
         </Suspense>,
       ),
@@ -371,7 +371,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
     render = pathMap["/default/payment/:result"];
     expect(JSON.stringify(render(createTestProps()))).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <PaymentStatus cookies={cookies} />
         </Suspense>,
       ),
@@ -379,7 +379,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
     render = pathMap.notFound;
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <ConnectedDoesNotExist />
         </Suspense>,
       ),
@@ -429,7 +429,7 @@ describe("Test Organization Wrapper for authenticated and unverified users", () 
     const cookies = new Cookies();
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <MobilePhoneVerification cookies={cookies} />
         </Suspense>,
       ),
@@ -449,7 +449,7 @@ describe("Test Organization Wrapper for authenticated and unverified users", () 
     render = pathMap["/default/change-password"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <PasswordChange cookies={cookies} />
         </Suspense>,
       ),
@@ -457,7 +457,7 @@ describe("Test Organization Wrapper for authenticated and unverified users", () 
     render = pathMap["/default/change-phone-number"];
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <MobilePhoneChange cookies={cookies} />
         </Suspense>,
       ),
@@ -465,7 +465,7 @@ describe("Test Organization Wrapper for authenticated and unverified users", () 
     render = pathMap["/default/payment/:result"];
     expect(JSON.stringify(render(createTestProps()))).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <PaymentStatus cookies={cookies} />
         </Suspense>,
       ),
@@ -473,7 +473,7 @@ describe("Test Organization Wrapper for authenticated and unverified users", () 
     render = pathMap.notFound;
     expect(JSON.stringify(render())).toEqual(
       JSON.stringify(
-        <Suspense fallback={<Loader full={false} />}>
+        <Suspense fallback={<Loader />}>
           <ConnectedDoesNotExist />
         </Suspense>,
       ),

--- a/client/components/status/__snapshots__/status.test.js.snap
+++ b/client/components/status/__snapshots__/status.test.js.snap
@@ -97,10 +97,12 @@ exports[`<Status /> rendering should render correctly 1`] = `
     </div>
   </div>
   <div
-    className="loadingContainer"
+    className="flex-column"
+    id="sessions"
   >
-    <p
-      className="loading"
+    <loader
+      full={false}
+      small={true}
     />
   </div>
   <React.Fragment>
@@ -260,10 +262,12 @@ exports[`<Status /> rendering with placeholder translation tags should render tr
     </div>
   </div>
   <div
-    className="loadingContainer"
+    className="flex-column"
+    id="sessions"
   >
-    <p
-      className="loading"
+    <loader
+      full={false}
+      small={true}
     />
   </div>
   <React.Fragment>

--- a/client/components/status/index.css
+++ b/client/components/status/index.css
@@ -58,28 +58,18 @@
   width: 75%;
   margin: 0 auto;
 }
-.loadingContainer {
-  padding-left: 50%;
-  position: relative;
-  top: -7px;
+#status.content {
+  flex-grow: 0;
 }
-.loading {
-  border: 8px solid #f3f3f3;
-  border-top: 8px solid #2b3a42;
-  border-radius: 50%;
-  width: 30px;
-  height: 30px;
-  animation: spin 0.8s linear infinite;
+#sessions {
+  flex-grow: 1;
+  justify-content: center;
+  max-width: 1000px;
+  margin: 0 auto;
 }
-@keyframes spin {
-  0% {
-    transform: rotate(0deg);
-  }
-  100% {
-    transform: rotate(360deg);
-  }
+#sessions > div {
+  width: 100%;
 }
-
 .logout-modal {
   position: fixed;
   left: 0;
@@ -91,13 +81,11 @@
   visibility: hidden;
   transition: opacity 0.3s 0s, visibility 0s 0.3s;
 }
-
 .logout-modal.is-visible {
   opacity: 1;
   visibility: visible;
   transition: opacity 0.3s 0s, visibility 0s 0s;
 }
-
 .logout-modal-container {
   position: absolute;
   top: 50%;
@@ -114,21 +102,17 @@
   transition-property: transform;
   transition-duration: 0.3s;
 }
-
 .logout-modal-container p {
   margin-top: 0;
 }
-
 .modal-container .modal-buttons {
   margin: 2.5em 0 0;
 }
-
 .modal-container .modal-buttons button {
   margin: 0 20px;
   padding-left: 25px;
   padding-right: 25px;
 }
-
 @media screen and (min-width: 0px) and (max-width: 500px) {
   .logout-modal-container p.message {
     margin: 0 6%;

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -21,6 +21,7 @@ import shouldLinkBeShown from "../../utils/should-link-be-shown";
 import handleSession from "../../utils/session";
 import validateToken from "../../utils/validate-token";
 import needsVerify from "../../utils/needs-verify";
+import Loader from "../../utils/loader";
 import {initialState} from "../../reducers/organization";
 import {Logout} from "../organization-wrapper/lazy-import";
 
@@ -618,11 +619,7 @@ export default class Status extends React.Component {
     return this.getSmallTable(session_info);
   };
 
-  getSpinner = () => (
-    <div className="loadingContainer">
-      <p className="loading" />
-    </div>
-  );
+  getSpinner = () => <Loader full={false} small />;
 
   getSessionInfo = () => ({
     header: {
@@ -761,17 +758,21 @@ export default class Status extends React.Component {
             <Contact />
           </div>
         </div>
-        {((activeSessions.length > 0 || pastSessions.length > 0) && (
-          <InfinteScroll
-            dataLength={pastSessions.length}
-            next={this.fetchMoreSessions}
-            hasMore={hasMoreSessions}
-            loader={this.getSpinner()}
-          >
-            <>{this.getTable(this.getSessionInfo())}</>
-          </InfinteScroll>
-        )) ||
-          (loadSpinner ? this.getSpinner() : null)}
+
+        <div id="sessions" className="flex-column">
+          {((activeSessions.length > 0 || pastSessions.length > 0) && (
+            <InfinteScroll
+              dataLength={pastSessions.length}
+              next={this.fetchMoreSessions}
+              hasMore={hasMoreSessions}
+              loader={this.getSpinner()}
+              style={{overflow: false}}
+            >
+              <>{this.getTable(this.getSessionInfo())}</>
+            </InfinteScroll>
+          )) ||
+            (loadSpinner ? this.getSpinner() : null)}
+        </div>
 
         {/* check to ensure this block of code is executed in root document and not in Iframe */}
         {captivePortalLoginForm && window.top === window.self && (

--- a/client/index.css
+++ b/client/index.css
@@ -171,7 +171,8 @@ body .input,
   max-width: 1000px;
 }
 .main-column,
-.main-column > .inner {
+.main-column > .inner,
+.flex-column {
   display: flex;
   flex-direction: column;
   justify-content: start;

--- a/client/utils/loader.js
+++ b/client/utils/loader.js
@@ -1,12 +1,14 @@
 import React from "react";
 
-const loader = (props) => (
-  <div
-    className={
-      props.full === true ? "full-page-loader-container" : "loader-container"
-    }
-  >
-    <div className="loader" />
-  </div>
-);
+const loader = (props) => {
+  const {full = true, small = false} = props;
+  let css = "loader-container";
+  if (full) css = `${css} full`;
+  if (small) css += " small";
+  return (
+    <div className={css}>
+      <div className="loader" />
+    </div>
+  );
+};
 export default loader;

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -555,17 +555,27 @@ describe("needs-verify tests", () => {
   });
 });
 describe("loader tests", () => {
-  it("should show loader with class full-page-loader-container", () => {
-    const wrapper = shallow(loader({full: true}));
+  it("should default to .loader-container.full", () => {
+    const wrapper = shallow(loader({}));
     expect(
       wrapper.contains(
-        <div className="full-page-loader-container">
+        <div className="loader-container full">
           <div className="loader" />
         </div>,
       ),
     ).toBe(true);
   });
-  it("should show loader with class loader-container", () => {
+  it("should show .loader-container.full", () => {
+    const wrapper = shallow(loader({full: true}));
+    expect(
+      wrapper.contains(
+        <div className="loader-container full">
+          <div className="loader" />
+        </div>,
+      ),
+    ).toBe(true);
+  });
+  it("should show .loader-container", () => {
     const wrapper = shallow(loader({full: false}));
     expect(
       wrapper.contains(

--- a/public/index.html
+++ b/public/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>WiFi Login Page</title>
+    <title></title>
   </head>
   <style>
     /*

--- a/public/index.html
+++ b/public/index.html
@@ -9,11 +9,21 @@
     <title>WiFi Login Page</title>
   </head>
   <style>
+    /*
+      The loading indicator needs to be loaded
+      right away, please do not remove this code
+    */
     html,
     body {
       overflow: hidden;
     }
-    #preload, .loader-container {
+    .loader-container {
+      display: flex;
+      flex-direction: row;
+      justify-content: center;
+      align-items: center;
+    }
+    .loader-container.full {
       width: 100%;
       height: 100%;
       position: fixed;
@@ -21,9 +31,6 @@
       left: 0;
       background: rgba(255, 255, 255, 1);
       z-index: 9998;
-      display: flex;
-      justify-content: center;
-      align-items: center;
     }
     .loader {
       border: 8px solid #f3f3f3;
@@ -33,7 +40,10 @@
       height: 50px;
       animation: spin 0.8s linear infinite;
     }
-    /* Loading Animation */
+    .small .loader {
+      width: 30px;
+      height: 30px;
+    }
     @keyframes spin {
       0% {
         transform: rotate(0deg);
@@ -44,7 +54,7 @@
     }
   </style>
   <body>
-    <div id="preload">
+    <div id="preload" class="loader-container full">
       <div class="loader"></div>
     </div>
     <div id="root"></div>


### PR DESCRIPTION
- [change] Removed <title> contents
  It makes more sense to leave this empty because it
  will be loaded at runtime.

- [change] Centralized loading indicator HTML & CSS
  We must avoid to redefine the HTML and CSS of the loading indicator
  in mutliple places.
  This logic was defined in:  
    - index.html
    - status
    - organization wrapper
    - model
  Now the HTML is defined in the <Loader> component, while the CSS
  is defined in the main <style> tag.

- [chores] Removed untranslated not found <title>
