### PR TITLE
[fix/change] Fixed hanging logout + force logout after payment #410

### DIFF
--- a/browser-test/mobile-phone-change.test.js
+++ b/browser-test/mobile-phone-change.test.js
@@ -7,6 +7,7 @@ import {
   initializeData,
   tearDown,
   getPhoneToken,
+  successToastSelector,
 } from "./utils";
 
 const fillPhoneField = async (driver, data) => {
@@ -48,7 +49,7 @@ describe("Selenium tests for <MobilePhoneChange />", () => {
     await fillPhoneField(driver, data);
     let submitBtn = await getElementByCss(driver, "input[type=submit]");
     submitBtn.click();
-    let successToastDiv = await getElementByCss(driver, "div[role=alert]");
+    let successToastDiv = await getElementByCss(driver, successToastSelector);
     await driver.wait(until.elementIsVisible(successToastDiv));
     expect(await driver.getCurrentUrl()).toEqual(
       urls.mobileVerification(data.organization),

--- a/browser-test/mobile-verfication.test.js
+++ b/browser-test/mobile-verfication.test.js
@@ -7,6 +7,7 @@ import {
   initializeData,
   tearDown,
   getPhoneToken,
+  successToastSelector,
 } from "./utils";
 
 const fillPhoneField = async (driver, data) => {
@@ -46,7 +47,7 @@ describe("Selenium tests for <MobileVerification />", () => {
     await fillPhoneField(driver, data);
     let submitBtn = await getElementByCss(driver, "input[type=submit]");
     submitBtn.click();
-    const successToastDiv = await getElementByCss(driver, "div[role=alert]");
+    const successToastDiv = await getElementByCss(driver, successToastSelector);
     await driver.wait(until.elementIsVisible(successToastDiv));
     expect(await driver.getCurrentUrl()).toEqual(
       urls.mobileVerification(data.organization),

--- a/browser-test/utils.js
+++ b/browser-test/utils.js
@@ -75,6 +75,8 @@ export const urls = {
     `http://0.0.0.0:8080/${slug}/change-phone-number`,
 };
 
+export const successToastSelector = ".Toastify__toast--success div[role=alert]";
+
 // increase the jest global test time out
 // because browser tests can take a bit longer to complete
 jest.setTimeout(10000);

--- a/client/actions/actions.test.js
+++ b/client/actions/actions.test.js
@@ -13,6 +13,7 @@ import logout from "./logout";
 import parseOrganizations from "./parse-organizations";
 import setLanguage from "./set-language";
 import setOrganization from "./set-organization";
+import {initialState} from "../reducers/organization";
 
 jest.mock("../utils/get-config");
 jest.mock("../utils/authenticate");
@@ -59,11 +60,7 @@ describe("actions testing", () => {
   it("should create actions to set current organization", async () => {
     const orgConfig = testOrgConfig[2];
     const orgConfig2 = testOrgConfig[1];
-    const userData = {
-      is_active: true,
-      is_verified: null,
-      mustLogin: true,
-    };
+    const {userData} = initialState;
     orgConfig.userData = userData;
     orgConfig2.userData = userData;
     testOrgConfig[0].userData = userData;

--- a/client/components/login/login.js
+++ b/client/components/login/login.js
@@ -198,6 +198,7 @@ export default class Login extends React.Component {
       errors: {},
     });
     setLoading(true);
+    this.waitToast = toast.info(t`PLEASE_WAIT`, {autoClose: 20000});
 
     return axios({
       method: "post",
@@ -252,9 +253,15 @@ export default class Login extends React.Component {
           },
         });
 
+        this.dismissWait();
         setLoading(false);
       });
   }
+
+  dismissWait = () => {
+    const {waitToast} = this;
+    if (waitToast) toast.dismiss(this.waitToast);
+  };
 
   handleAuthentication = (data = {}, useSessionStorage = false) => {
     const {orgSlug, authenticate, setUserData} = this.props;
@@ -267,6 +274,7 @@ export default class Login extends React.Component {
     if (!remember_me || useSessionStorage) {
       sessionStorage.setItem(`${orgSlug}_auth_token`, data.key);
     }
+    this.dismissWait();
     toast.success(t`LOGIN_SUCCESS`, {
       toastId: mainToastId,
     });

--- a/client/components/organization-wrapper/lazy-import.js
+++ b/client/components/organization-wrapper/lazy-import.js
@@ -11,9 +11,6 @@ export const Registration = React.lazy(() => import("../registration"));
 export const Status = lazyWithPreload(() =>
   import(/* webpackChunkName: 'Status' */ "../status"),
 );
-export const Login = React.lazy(() =>
-  import(/* webpackChunkName: 'Login' */ "../login"),
-);
 export const PasswordChange = React.lazy(() => import("../password-change"));
 export const MobilePhoneChange = React.lazy(() =>
   import("../mobile-phone-change"),

--- a/client/components/organization-wrapper/organization-wrapper.js
+++ b/client/components/organization-wrapper/organization-wrapper.js
@@ -16,8 +16,8 @@ import LoadingContext from "../../utils/loading-context";
 import Loader from "../../utils/loader";
 import needsVerify from "../../utils/needs-verify";
 import loadTranslation from "../../utils/load-translation";
+import Login from "../login";
 import {
-  Login,
   Registration,
   Status,
   PasswordChange,
@@ -213,11 +213,7 @@ export default class OrganizationWrapper extends React.Component {
                     render={(props) => {
                       if (isAuthenticated && is_active)
                         return <Redirect to={`/${orgSlug}/status`} />;
-                      return (
-                        <Suspense fallback={<Loader />}>
-                          <Login {...props} />
-                        </Suspense>
-                      );
+                      return <Login {...props} />;
                     }}
                   />
                   <Route

--- a/client/components/organization-wrapper/organization-wrapper.test.js
+++ b/client/components/organization-wrapper/organization-wrapper.test.js
@@ -11,8 +11,8 @@ import OrganizationWrapper from "./organization-wrapper";
 import Footer from "../footer";
 import Loader from "../../utils/loader";
 import needsVerify from "../../utils/needs-verify";
+import Login from "../login";
 import {
-  Login,
   Registration,
   Status,
   PasswordChange,
@@ -371,13 +371,7 @@ describe("Test Organization Wrapper for unauthenticated users", () => {
       ),
     );
     render = pathMap["/default/login"];
-    expect(JSON.stringify(render())).toEqual(
-      JSON.stringify(
-        <Suspense fallback={<Loader />}>
-          <Login />
-        </Suspense>,
-      ),
-    );
+    expect(JSON.stringify(render())).toEqual(JSON.stringify(<Login />));
     render = pathMap["/default/status"];
     // userAutoLogin is true
     expect(render()).toEqual(<Redirect to="/default/logout" />);

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -347,17 +347,16 @@ export default class Status extends React.Component {
     if (!this.logoutIframeRef || !this.logoutIframeRef.current) {
       return;
     }
-    const {userData, setUserData, statusPage, orgSlug} = this.props;
+    const {setUserData, statusPage, orgSlug, logout, cookies} = this.props;
     const {saml_logout_url} = statusPage;
     const {loggedOut} = this.state;
     const {repeatLogin} = this;
     const {setLoading} = this.context;
     const logoutMethodKey = `${orgSlug}_logout_method`;
     const logoutMethod = localStorage.getItem(logoutMethodKey);
+    const userAutoLogin = localStorage.getItem("userAutoLogin") === "true";
 
     if (loggedOut) {
-      const {logout, cookies} = this.props;
-      const userAutoLogin = localStorage.getItem("userAutoLogin") === "true";
       logout(cookies, orgSlug, userAutoLogin);
       toast.success(t`LOGOUT_SUCCESS`);
 
@@ -371,16 +370,16 @@ export default class Status extends React.Component {
     }
 
     if (repeatLogin) {
-      userData.mustLogin = true;
-      userData.mustLogout = false;
-      userData.repeatLogin = false;
-      // will trigger the creation of a new radius token
-      userData.radius_user_token = undefined;
       this.repeatLogin = false;
-      setUserData(userData);
       // wait to trigger login to avoid getting stuck
       // in captive portal firewall rule reloading
-      setTimeout(async () => this.componentDidMount(), 1000);
+      toast.info(t`PLEASE_WAIT`, {autoClose: 6000});
+      setTimeout(async () => {
+        toast.info(t`PLEASE_LOGIN`, {autoClose: 10000});
+        setUserData(initialState.userData);
+        setLoading(false);
+        logout(cookies, orgSlug, userAutoLogin);
+      }, 6000);
     }
   };
 

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -196,11 +196,9 @@ describe("<Status /> interactions", () => {
     await tick();
     expect(wrapper.instance().state.activeSessions.length).toBe(1);
     expect(wrapper.instance().props.logout).toHaveBeenCalled();
-    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith({
-      is_active: true,
-      is_verified: null,
-      mustLogin: true,
-    });
+    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
+      initialState.userData,
+    );
   });
 
   it("test componentDidMount lifecycle method", async () => {
@@ -913,27 +911,19 @@ describe("<Status /> interactions", () => {
     await tick();
     expect(status.repeatLogin).toBe(true);
     await status.handleLogoutIframe();
-    jest.advanceTimersByTime(1000);
+    jest.runAllTimers();
     expect(status.state.loggedOut).toBe(false);
     expect(status.repeatLogin).toBe(false);
     expect(mockRef.submit.mock.calls.length).toBe(1);
     expect(handleLogout).toHaveBeenCalledWith(false, true);
-    expect(status.props.logout).not.toHaveBeenCalled();
-    expect(setLoading.mock.calls).toEqual([[true], [true], [true]]);
+    expect(status.props.logout).toHaveBeenCalled();
+    expect(setLoading.mock.calls).toEqual([[true], [true], [false]]);
     expect(Status.prototype.getUserActiveRadiusSessions.mock.calls.length).toBe(
       1,
     );
-    expect(componentDidMount.mock.calls.length).toBe(1);
+    expect(componentDidMount.mock.calls.length).toBe(0);
     expect(setUserData.mock.calls.length).toBe(1);
-    const userData = {
-      ...responseData,
-      mustLogin: true,
-      mustLogout: false,
-      repeatLogin: false,
-      radius_user_token: undefined,
-    };
-    expect(setUserData).toHaveBeenCalledWith(userData);
-    expect(status.props.userData).toStrictEqual(userData);
+    expect(setUserData).toHaveBeenCalledWith(initialState.userData);
     expect(spyToast.mock.calls.length).toBe(0);
   });
 

--- a/client/reducers/organization.js
+++ b/client/reducers/organization.js
@@ -21,6 +21,10 @@ export const initialState = {
     is_active: true,
     is_verified: null,
     mustLogin: true,
+    mustLogout: false,
+    repeatLogin: false,
+    auth_token: undefined,
+    radius_user_token: undefined,
   },
   settings: {
     mobile_phone_verification: undefined,

--- a/client/reducers/reducers.test.js
+++ b/client/reducers/reducers.test.js
@@ -33,9 +33,14 @@ describe("organization reducer", () => {
         is_active: true,
         is_verified: null,
         mustLogin: true,
+        mustLogout: false,
+        repeatLogin: false,
+        auth_token: undefined,
+        radius_user_token: undefined,
       },
       settings: {
         mobile_phone_verification: undefined,
+        subscriptions: undefined,
       },
     },
   };

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -23,6 +23,7 @@ import needsVerify from "./needs-verify";
 import loader from "./loader";
 import handleChange from "./handle-change";
 import redirectToPayment from "./redirect-to-payment";
+import {initialState} from "../reducers/organization";
 
 jest.mock("axios");
 jest.mock("./load-translation");
@@ -305,9 +306,7 @@ describe("Validate Token tests", () => {
     );
     expect(setUserData.mock.calls.length).toBe(1);
     expect(console.log).toHaveBeenCalledWith(response);
-    expect(setUserData.mock.calls.pop()).toEqual([
-      {is_active: true, is_verified: null, mustLogin: true},
-    ]);
+    expect(setUserData.mock.calls.pop()).toEqual([initialState.userData]);
   });
 });
 describe("password-toggle tests", () => {

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -24,90 +24,90 @@ msgstr "AGB"
 
 #: client/components/login/login.js:220
 #: client/components/registration/registration.js:86
-#: client/components/status/status.js:243
-#: client/components/status/status.js:246
+#: client/components/status/status.js:247
+#: client/components/status/status.js:251
 #: client/utils/handle-logout.js:34
 #: client/utils/validate-token.js:45
 msgid "ERR_OCCUR"
 msgstr "Ein fehler ist aufgetreten!"
 
-#: client/components/status/status.js:295
-#: client/components/status/status.js:357
+#: client/components/status/status.js:300
+#: client/components/status/status.js:361
 #: client/utils/handle-logout.js:33
 msgid "LOGOUT_SUCCESS"
 msgstr "Abmeldung erfolgreich"
 
-#: client/components/status/status.js:443
-#: client/components/status/status.js:634
+#: client/components/status/status.js:467
+#: client/components/status/status.js:658
 msgid "ACCT_ACTIVE"
 msgstr "Sitzung ist aktiv"
 
 #: client/components/logout/logout.js:23
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:265
-#: client/components/status/status.js:467
-#: client/components/status/status.js:548
-#: client/components/status/status.js:730
+#: client/components/status/status.js:491
+#: client/components/status/status.js:572
+#: client/components/status/status.js:754
 msgid "LOGOUT"
 msgstr "Abmelden"
 
-#: client/components/status/status.js:626
+#: client/components/status/status.js:650
 msgid "ACCT_START_TIME"
 msgstr "Startzeit"
 
-#: client/components/status/status.js:627
+#: client/components/status/status.js:651
 msgid "ACCT_STOP_TIME"
 msgstr "Stoppzeit"
 
-#: client/components/status/status.js:628
+#: client/components/status/status.js:652
 msgid "ACCT_DURATION"
 msgstr "Dauer"
 
-#: client/components/status/status.js:629
+#: client/components/status/status.js:653
 msgid "ACCT_DOWNLOAD"
 msgstr "Herunterladen"
 
-#: client/components/status/status.js:630
+#: client/components/status/status.js:654
 msgid "ACCT_UPLOAD"
 msgstr "Hochladen"
 
-#: client/components/status/status.js:631
+#: client/components/status/status.js:655
 msgid "ACCT_DEVICE_ADDRESS"
 msgstr "Geräteadresse"
 
-#: client/components/status/status.js:640
+#: client/components/status/status.js:664
 msgid "STATUS"
 msgstr "Status"
 
-#: client/components/status/status.js:641
+#: client/components/status/status.js:665
 msgid "LOGGED_IN"
 msgstr "Angemeldet"
 
-#: client/components/status/status.js:647
+#: client/components/status/status.js:671
 msgid "USERNAME"
 msgstr "Benutzername"
 
 #: client/components/contact-box/contact.js:25
 #: client/components/password-reset/password-reset.js:106
-#: client/components/registration/registration.js:469
-#: client/components/status/status.js:644
+#: client/components/registration/registration.js:467
+#: client/components/status/status.js:668
 msgid "EMAIL"
 msgstr "Email"
 
-#: client/components/status/status.js:650
+#: client/components/status/status.js:674
 msgid "PHONE_NUMBER"
 msgstr "Telefonnummer"
 
-#: client/components/status/status.js:691
+#: client/components/status/status.js:715
 msgid "LOGOUT_MODAL_CONTENT"
 msgstr "Möchten Sie sich beim nächsten Mal automatisch anmelden?"
 
-#: client/components/registration/registration.js:300
+#: client/components/registration/registration.js:298
 msgid "PLAN_SETTING_TXT"
 msgstr "Bitte wählen Sie das gewünschte Abonnement aus"
 
 #: client/components/login/login.js:139
 #: client/components/mobile-phone-change/mobile-phone-change.js:139
-#: client/components/registration/registration.js:392
+#: client/components/registration/registration.js:390
 msgid "PHONE_LBL"
 msgstr "Mobiltelefonnummer"
 
@@ -115,18 +115,18 @@ msgstr "Mobiltelefonnummer"
 #: client/components/login/login.js:172
 #: client/components/mobile-phone-change/mobile-phone-change.js:155
 #: client/components/mobile-phone-change/mobile-phone-change.js:180
-#: client/components/registration/registration.js:416
-#: client/components/registration/registration.js:450
+#: client/components/registration/registration.js:414
+#: client/components/registration/registration.js:448
 msgid "PHONE_PHOLD"
 msgstr "handynummer eingeben"
 
 #: client/components/password-reset/password-reset.js:116
-#: client/components/registration/registration.js:479
+#: client/components/registration/registration.js:477
 msgid "EMAIL_PHOLD"
 msgstr "email adresse"
 
 #: client/components/password-reset/password-reset.js:118
-#: client/components/registration/registration.js:482
+#: client/components/registration/registration.js:480
 msgid "EMAIL_PTRN_DESC"
 msgstr "Gültige E-Mail-Adresse eingeben"
 
@@ -138,140 +138,140 @@ msgstr "E-Mail, Telefonnummer oder Benutzername"
 msgid "USERNAME_LOG_PHOLD"
 msgstr "email, telefonnummer oder benutzername eingeben"
 
-#: client/components/registration/registration.js:505
+#: client/components/registration/registration.js:503
 msgid "USERNAME_PTRN_DESC"
 msgstr "nur Buchstaben, Zahlen und @/./+/-/_ Zeichen"
 
-#: client/components/registration/registration.js:515
-#: client/components/registration/registration.js:516
+#: client/components/registration/registration.js:513
+#: client/components/registration/registration.js:514
 msgid "FIRST_NAME_LBL"
 msgstr "Vorname"
 
-#: client/components/registration/registration.js:533
+#: client/components/registration/registration.js:531
 msgid "FIRST_NAME_PHOLD"
 msgstr "vorname"
 
-#: client/components/registration/registration.js:543
-#: client/components/registration/registration.js:544
+#: client/components/registration/registration.js:541
+#: client/components/registration/registration.js:542
 msgid "LAST_NAME_LBL"
 msgstr "Nachname"
 
-#: client/components/registration/registration.js:516
-#: client/components/registration/registration.js:544
-#: client/components/registration/registration.js:571
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:514
+#: client/components/registration/registration.js:542
+#: client/components/registration/registration.js:569
+#: client/components/registration/registration.js:594
 msgid "OPTIONAL"
 msgstr "optional"
 
-#: client/components/registration/registration.js:561
+#: client/components/registration/registration.js:559
 msgid "LAST_NAME_PHOLD"
 msgstr "nachname"
 
-#: client/components/registration/registration.js:570
-#: client/components/registration/registration.js:571
+#: client/components/registration/registration.js:568
+#: client/components/registration/registration.js:569
 msgid "BIRTH_DATE_LBL"
 msgstr "Geburtsdatum"
 
-#: client/components/registration/registration.js:595
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:593
+#: client/components/registration/registration.js:594
 msgid "LOCATION_LBL"
 msgstr "Standort"
 
-#: client/components/registration/registration.js:611
+#: client/components/registration/registration.js:609
 msgid "LOCATION_PHOLD"
 msgstr "standort"
 
-#: client/components/registration/registration.js:614
+#: client/components/registration/registration.js:612
 msgid "LOCATION_PTRN_DESC"
 msgstr "nur Buchstaben, Zahlen, Leerzeichen, Satzzeichen"
 
-#: client/components/login/login.js:348
+#: client/components/login/login.js:347
 #: client/components/password-confirm/password-confirm.js:145
-#: client/components/registration/registration.js:620
+#: client/components/registration/registration.js:618
 msgid "PWD_LBL"
 msgstr "Passwort"
 
-#: client/components/login/login.js:358
+#: client/components/login/login.js:357
 #: client/components/password-confirm/password-confirm.js:156
-#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:628
 msgid "PWD_PHOLD"
 msgstr "passwort"
 
-#: client/components/login/login.js:360
+#: client/components/login/login.js:359
 #: client/components/password-change/password-change.js:129
 #: client/components/password-change/password-change.js:155
 #: client/components/password-confirm/password-confirm.js:158
 #: client/components/password-confirm/password-confirm.js:186
-#: client/components/registration/registration.js:632
-#: client/components/registration/registration.js:661
+#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:659
 msgid "PWD_PTRN_DESC"
 msgstr "Passwort muss mindestens 6 Zeichen lang sein"
 
 #: client/components/password-change/password-change.js:143
 #: client/components/password-confirm/password-confirm.js:173
-#: client/components/registration/registration.js:648
+#: client/components/registration/registration.js:646
 msgid "CONFIRM_PWD_LBL"
 msgstr "Kennwort bestätigen"
 
 #: client/components/password-change/password-change.js:153
 #: client/components/password-confirm/password-confirm.js:184
-#: client/components/registration/registration.js:659
+#: client/components/registration/registration.js:657
 msgid "CONFIRM_PWD_PHOLD"
 msgstr "kennwort bestätigen"
 
-#: client/components/registration/registration.js:679
+#: client/components/registration/registration.js:677
 msgid "COUNTRY_LBL"
 msgstr "kennwort bestätigen"
 
-#: client/components/registration/registration.js:688
+#: client/components/registration/registration.js:686
 msgid "CITY_LBL"
 msgstr "Stadt"
 
-#: client/components/registration/registration.js:701
+#: client/components/registration/registration.js:699
 msgid "CITY_PHOLD"
 msgstr "stadt betreten"
 
-#: client/components/registration/registration.js:705
+#: client/components/registration/registration.js:703
 msgid "STREET_LBL"
 msgstr "Straße"
 
-#: client/components/registration/registration.js:718
+#: client/components/registration/registration.js:716
 msgid "STREET_PHOLD"
 msgstr "straße eingeben"
 
-#: client/components/registration/registration.js:722
+#: client/components/registration/registration.js:720
 msgid "ZIP_CODE_LBL"
 msgstr "Postleitzahl"
 
-#: client/components/registration/registration.js:739
+#: client/components/registration/registration.js:737
 msgid "TAX_NUMBER_LBL"
 msgstr "Steuernummer"
 
-#: client/components/registration/registration.js:751
+#: client/components/registration/registration.js:749
 msgid "TAX_NUMBER_PHOLD"
 msgstr "geben Sie Ihre Steueridentifikationsnummer ein (optional)"
 
-#: client/components/registration/registration.js:753
+#: client/components/registration/registration.js:751
 msgid "TAX_NUMBER_PTRN_DESC"
 msgstr "nur Zahlen und Buchstaben"
 
-#: client/components/registration/registration.js:768
+#: client/components/registration/registration.js:766
 msgid "REGISTER_ADD_INFO_TXT"
 msgstr ""
 "Mit der Anmeldung akzeptieren Sie die {terms_and_conditions} und die "
 "{privacy_policy} dieses WLAN-Dienstes."
 
-#: client/components/login/login.js:404
-#: client/components/registration/registration.js:781
+#: client/components/login/login.js:403
+#: client/components/registration/registration.js:779
 msgid "REGISTER_BTN_TXT"
 msgstr "Anmelden"
 
-#: client/components/login/login.js:412
-#: client/components/registration/registration.js:794
+#: client/components/login/login.js:411
+#: client/components/registration/registration.js:792
 msgid "FORGOT_PASSWORD"
 msgstr "Passwort vergessen?"
 
-#: client/components/registration/registration.js:801
+#: client/components/registration/registration.js:799
 msgid "LINKS_LOGIN_TXT"
 msgstr "Haben Sie bereits ein Konto? Einloggen"
 
@@ -291,30 +291,30 @@ msgstr "Die beiden Passwortfelder stimmten nicht überein"
 msgid "REGISTER_SUCCESS"
 msgstr "Registrierung erfolgreich"
 
-#: client/components/registration/registration.js:225
+#: client/components/registration/registration.js:222
 msgid "REGISTER_ERR"
 msgstr "Registrierungsfehler."
 
-#: client/components/payment-status/payment-status.js:78
+#: client/components/payment-status/payment-status.js:84
 msgid "PAY_SUCCESS"
 msgstr "Zahlung erfolgreich erhalten."
 
-#: client/components/payment-status/payment-status.js:137
+#: client/components/payment-status/payment-status.js:143
 #. failed payment case
 msgid "PAY_FAIL"
 msgstr "Bezahlung fehlgeschlagen"
 
-#: client/components/payment-status/payment-status.js:138
+#: client/components/payment-status/payment-status.js:144
 #. failed payment case
 msgid "PAY_SUB_H"
 msgstr "Bei der Zahlung ist etwas schief gelaufen."
 
-#: client/components/payment-status/payment-status.js:141
+#: client/components/payment-status/payment-status.js:147
 #. failed payment case
 msgid "PAY_TRY_AGAIN_BTN"
 msgstr "Versuchen Sie es nochmal"
 
-#: client/components/payment-status/payment-status.js:146
+#: client/components/payment-status/payment-status.js:152
 #. failed payment case
 msgid "PAY_GIVE_UP_TXT"
 msgstr ""
@@ -322,8 +322,8 @@ msgstr ""
 "versuchen, uns zu kontaktieren.bei Ihrer Bank oder brechen Sie den Vorgang "
 "ab."
 
-#: client/components/payment-status/payment-status.js:119
-#: client/components/payment-status/payment-status.js:152
+#: client/components/payment-status/payment-status.js:125
+#: client/components/payment-status/payment-status.js:158
 msgid "PAY_GIVE_UP_BTN"
 msgstr "Vorgang abbrechen und abmelden"
 
@@ -394,7 +394,7 @@ msgstr "ihr neues passwort"
 msgid "PASSWORD_CHANGE"
 msgstr "Passwort ändern"
 
-#: client/components/organization-wrapper/organization-wrapper.js:297
+#: client/components/organization-wrapper/organization-wrapper.js:306
 #, javascript-format
 msgid "DEFAULT_TITL${ orgName }"
 msgstr "WiFi-Anmeldung - ${ orgName }"
@@ -465,7 +465,7 @@ msgid "LOGOUT_CONTENT"
 msgstr "Abmeldung erfolgreich"
 
 #: client/components/login/login.js:52
-#: client/components/login/login.js:393
+#: client/components/login/login.js:392
 msgid "LOGIN"
 msgstr "Einloggen"
 
@@ -489,17 +489,17 @@ msgstr ""
 msgid "LOGIN_ERR"
 msgstr "Login-Fehler aufgetreten."
 
-#: client/components/login/login.js:375
+#: client/components/login/login.js:374
 msgid "REMEMBER_ME"
 msgstr "Erinnere dich an mich auf diesem Gerät"
 
-#: client/components/login/login.js:382
+#: client/components/login/login.js:381
 msgid "LOGIN_ADD_INFO_TXT"
 msgstr ""
 "Durch die Anmeldung akzeptieren Sie die {terms_and_conditions} und die "
 "{privacy_policy} dieses WLAN-Dienstes. "
 
-#: client/components/login/login.js:399
+#: client/components/login/login.js:398
 msgid "REGISTER_BTN_LBL"
 msgstr "Noch nicht registriert?"
 
@@ -531,18 +531,18 @@ msgstr "Go back to homepage"
 msgid "STATUS_TITL"
 msgstr "Status"
 
-#: client/components/status/status.js:678
+#: client/components/status/status.js:702
 msgid "STATUS_CONTENT"
 msgstr ""
 "WiFi-Anmeldung erfolgreich!\n"
 "Sie können jetzt das Internet nutzen.\n"
 "Sie können diese Seite geöffnet lassen, falls Sie sich abmelden möchten."
 
-#: client/components/status/status.js:699
+#: client/components/status/status.js:723
 msgid "YES"
 msgstr "Ja"
 
-#: client/components/status/status.js:706
+#: client/components/status/status.js:730
 msgid "NO"
 msgstr "Nein"
 
@@ -550,29 +550,29 @@ msgstr "Nein"
 msgid "MOBILE_PHONE_VERIFY"
 msgstr "Einreichen"
 
-#: client/components/registration/registration.js:489
+#: client/components/registration/registration.js:487
 msgid "USERNAME_REG_LBL"
 msgstr "Username"
 
-#: client/components/registration/registration.js:502
+#: client/components/registration/registration.js:500
 msgid "USERNAME_REG_PHOLD"
 msgstr "Username"
 
-#: client/components/status/status.js:873
+#: client/components/status/status.js:897
 msgid "CP_LOGIN"
 msgstr ""
 "Wir initialisieren Ihre Sitzung im WiFi-Dienst, es kann einige Sekunden "
 "dauern, bitte warten Sie ..."
 
-#: client/components/payment-status/payment-status.js:94
+#: client/components/payment-status/payment-status.js:100
 msgid "PAY_REQ"
 msgstr "Zahlung erforderlich, um fortzufahren"
 
-#: client/components/payment-status/payment-status.js:109
+#: client/components/payment-status/payment-status.js:115
 msgid "PAY_PROC_BTN"
 msgstr "Fahren Sie mit der Zahlung fort"
 
-#: client/components/payment-status/payment-status.js:99
+#: client/components/payment-status/payment-status.js:105
 #, javascript-format
 msgid "PAY_WARN${ timeout }${ maxAttempts }"
 msgstr ""
@@ -587,3 +587,13 @@ msgstr ""
 "Sie Wenn dies passiert, wird die Website Ihrer Bank geschlossen. Sie können "
 "sich einfach mit den soeben registrierten Zugangsdaten erneut einloggen und "
 "Wiederholen Sie den Vorgang maximal ${ maxAttempts } Mal.</p>"
+
+#: client/components/status/status.js:375
+#. wait to trigger login to avoid getting stuck
+#. in captive portal firewall rule reloading
+msgid "PLEASE_WAIT"
+msgstr "Bitte warten..."
+
+#: client/components/status/status.js:377
+msgid "PLEASE_LOGIN"
+msgstr "Bitte loggen Sie sich ein"

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -22,16 +22,16 @@ msgstr "privacy policy"
 msgid "TOS_TITL"
 msgstr "terms and conditions"
 
-#: client/components/status/status.js:443
-#: client/components/status/status.js:634
+#: client/components/status/status.js:467
+#: client/components/status/status.js:658
 msgid "ACCT_ACTIVE"
 msgstr "session is active"
 
 #: client/components/logout/logout.js:23
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:265
-#: client/components/status/status.js:467
-#: client/components/status/status.js:548
-#: client/components/status/status.js:730
+#: client/components/status/status.js:491
+#: client/components/status/status.js:572
+#: client/components/status/status.js:754
 msgid "LOGOUT"
 msgstr "Logout"
 
@@ -39,72 +39,72 @@ msgstr "Logout"
 msgid "STATUS_TITL"
 msgstr "Status"
 
-#: client/components/status/status.js:626
+#: client/components/status/status.js:650
 msgid "ACCT_START_TIME"
 msgstr "Start time"
 
-#: client/components/status/status.js:627
+#: client/components/status/status.js:651
 msgid "ACCT_STOP_TIME"
 msgstr "Stop time"
 
-#: client/components/status/status.js:628
+#: client/components/status/status.js:652
 msgid "ACCT_DURATION"
 msgstr "Duration"
 
-#: client/components/status/status.js:629
+#: client/components/status/status.js:653
 msgid "ACCT_DOWNLOAD"
 msgstr "Download"
 
-#: client/components/status/status.js:630
+#: client/components/status/status.js:654
 msgid "ACCT_UPLOAD"
 msgstr "Upload"
 
-#: client/components/status/status.js:631
+#: client/components/status/status.js:655
 msgid "ACCT_DEVICE_ADDRESS"
 msgstr "Device address"
 
-#: client/components/status/status.js:640
+#: client/components/status/status.js:664
 msgid "STATUS"
 msgstr "Status"
 
-#: client/components/status/status.js:641
+#: client/components/status/status.js:665
 msgid "LOGGED_IN"
 msgstr "Logged in"
 
-#: client/components/status/status.js:647
+#: client/components/status/status.js:671
 msgid "USERNAME"
 msgstr "Username"
 
-#: client/components/status/status.js:650
+#: client/components/status/status.js:674
 msgid "PHONE_NUMBER"
 msgstr "Phone number"
 
-#: client/components/status/status.js:678
+#: client/components/status/status.js:702
 msgid "STATUS_CONTENT"
 msgstr ""
 "WiFi Login Successful!\n"
 "        You can now use the internet.\n"
 "        You may leave this page open in case you want to log out."
 
-#: client/components/status/status.js:691
+#: client/components/status/status.js:715
 msgid "LOGOUT_MODAL_CONTENT"
 msgstr "Do you want to automatically log in the next time?"
 
-#: client/components/status/status.js:699
+#: client/components/status/status.js:723
 msgid "YES"
 msgstr "Yes"
 
-#: client/components/status/status.js:706
+#: client/components/status/status.js:730
 msgid "NO"
 msgstr "No"
 
-#: client/components/registration/registration.js:300
+#: client/components/registration/registration.js:298
 msgid "PLAN_SETTING_TXT"
 msgstr "Please select the preferred subscription plan"
 
 #: client/components/login/login.js:139
 #: client/components/mobile-phone-change/mobile-phone-change.js:139
-#: client/components/registration/registration.js:392
+#: client/components/registration/registration.js:390
 msgid "PHONE_LBL"
 msgstr "Mobile phone number"
 
@@ -112,18 +112,18 @@ msgstr "Mobile phone number"
 #: client/components/login/login.js:172
 #: client/components/mobile-phone-change/mobile-phone-change.js:155
 #: client/components/mobile-phone-change/mobile-phone-change.js:180
-#: client/components/registration/registration.js:416
-#: client/components/registration/registration.js:450
+#: client/components/registration/registration.js:414
+#: client/components/registration/registration.js:448
 msgid "PHONE_PHOLD"
 msgstr "enter mobile phone number"
 
 #: client/components/password-reset/password-reset.js:116
-#: client/components/registration/registration.js:479
+#: client/components/registration/registration.js:477
 msgid "EMAIL_PHOLD"
 msgstr "email address"
 
 #: client/components/password-reset/password-reset.js:118
-#: client/components/registration/registration.js:482
+#: client/components/registration/registration.js:480
 msgid "EMAIL_PTRN_DESC"
 msgstr "enter valid email address"
 
@@ -135,116 +135,116 @@ msgstr "Email, phone number or username"
 msgid "USERNAME_LOG_PHOLD"
 msgstr "enter email, phone number or username"
 
-#: client/components/registration/registration.js:505
+#: client/components/registration/registration.js:503
 msgid "USERNAME_PTRN_DESC"
 msgstr "only letters, numbers and @/./+/-/_ characters"
 
-#: client/components/registration/registration.js:515
-#: client/components/registration/registration.js:516
+#: client/components/registration/registration.js:513
+#: client/components/registration/registration.js:514
 msgid "FIRST_NAME_LBL"
 msgstr "First name"
 
-#: client/components/registration/registration.js:533
+#: client/components/registration/registration.js:531
 msgid "FIRST_NAME_PHOLD"
 msgstr "first name"
 
-#: client/components/registration/registration.js:543
-#: client/components/registration/registration.js:544
+#: client/components/registration/registration.js:541
+#: client/components/registration/registration.js:542
 msgid "LAST_NAME_LBL"
 msgstr "Last name"
 
-#: client/components/registration/registration.js:561
+#: client/components/registration/registration.js:559
 msgid "LAST_NAME_PHOLD"
 msgstr "last name"
 
-#: client/components/registration/registration.js:570
-#: client/components/registration/registration.js:571
+#: client/components/registration/registration.js:568
+#: client/components/registration/registration.js:569
 msgid "BIRTH_DATE_LBL"
 msgstr "Birth date"
 
-#: client/components/registration/registration.js:595
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:593
+#: client/components/registration/registration.js:594
 msgid "LOCATION_LBL"
 msgstr "Location"
 
-#: client/components/registration/registration.js:611
+#: client/components/registration/registration.js:609
 msgid "LOCATION_PHOLD"
 msgstr "location"
 
-#: client/components/registration/registration.js:614
+#: client/components/registration/registration.js:612
 msgid "LOCATION_PTRN_DESC"
 msgstr "only letters, numbers, spaces, punctuation"
 
-#: client/components/login/login.js:348
+#: client/components/login/login.js:347
 #: client/components/password-confirm/password-confirm.js:145
-#: client/components/registration/registration.js:620
+#: client/components/registration/registration.js:618
 msgid "PWD_LBL"
 msgstr "Password"
 
-#: client/components/login/login.js:358
+#: client/components/login/login.js:357
 #: client/components/password-confirm/password-confirm.js:156
-#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:628
 msgid "PWD_PHOLD"
 msgstr "password"
 
-#: client/components/login/login.js:360
+#: client/components/login/login.js:359
 #: client/components/password-change/password-change.js:129
 #: client/components/password-change/password-change.js:155
 #: client/components/password-confirm/password-confirm.js:158
 #: client/components/password-confirm/password-confirm.js:186
-#: client/components/registration/registration.js:632
-#: client/components/registration/registration.js:661
+#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:659
 msgid "PWD_PTRN_DESC"
 msgstr "password must be a minimum of 6 characters"
 
-#: client/components/registration/registration.js:679
+#: client/components/registration/registration.js:677
 msgid "COUNTRY_LBL"
 msgstr "Country"
 
-#: client/components/registration/registration.js:688
+#: client/components/registration/registration.js:686
 msgid "CITY_LBL"
 msgstr "City"
 
-#: client/components/registration/registration.js:701
+#: client/components/registration/registration.js:699
 msgid "CITY_PHOLD"
 msgstr "enter city"
 
-#: client/components/registration/registration.js:705
+#: client/components/registration/registration.js:703
 msgid "STREET_LBL"
 msgstr "Street"
 
-#: client/components/registration/registration.js:718
+#: client/components/registration/registration.js:716
 msgid "STREET_PHOLD"
 msgstr "enter street"
 
-#: client/components/registration/registration.js:722
+#: client/components/registration/registration.js:720
 msgid "ZIP_CODE_LBL"
 msgstr "Postal code"
 
-#: client/components/registration/registration.js:739
+#: client/components/registration/registration.js:737
 msgid "TAX_NUMBER_LBL"
 msgstr "Tax number"
 
-#: client/components/registration/registration.js:751
+#: client/components/registration/registration.js:749
 msgid "TAX_NUMBER_PHOLD"
 msgstr "enter your tax identification number (optional)"
 
-#: client/components/registration/registration.js:753
+#: client/components/registration/registration.js:751
 msgid "TAX_NUMBER_PTRN_DESC"
 msgstr "only numbers and letters"
 
-#: client/components/registration/registration.js:768
+#: client/components/registration/registration.js:766
 msgid "REGISTER_ADD_INFO_TXT"
 msgstr ""
 "By signing up, you accept the {terms_and_conditions} and the "
 "{privacy_policy} of this WiFi service."
 
-#: client/components/login/login.js:412
-#: client/components/registration/registration.js:794
+#: client/components/login/login.js:411
+#: client/components/registration/registration.js:792
 msgid "FORGOT_PASSWORD"
 msgstr "Forgot your password?"
 
-#: client/components/registration/registration.js:801
+#: client/components/registration/registration.js:799
 msgid "LINKS_LOGIN_TXT"
 msgstr "Already have an account? Log in"
 
@@ -252,34 +252,34 @@ msgstr "Already have an account? Log in"
 msgid "REGISTRATION_TITL"
 msgstr "Sign up"
 
-#: client/components/payment-status/payment-status.js:78
+#: client/components/payment-status/payment-status.js:84
 msgid "PAY_SUCCESS"
 msgstr "Payment received successfully."
 
-#: client/components/payment-status/payment-status.js:136
+#: client/components/payment-status/payment-status.js:143
 #. failed payment case
 msgid "PAY_FAIL"
 msgstr "Payment Failed"
 
-#: client/components/payment-status/payment-status.js:138
+#: client/components/payment-status/payment-status.js:144
 #. failed payment case
 msgid "PAY_SUB_H"
 msgstr "Something went wrong with the payment."
 
-#: client/components/payment-status/payment-status.js:141
+#: client/components/payment-status/payment-status.js:147
 #. failed payment case
 msgid "PAY_TRY_AGAIN_BTN"
 msgstr "Try again"
 
-#: client/components/payment-status/payment-status.js:146
+#: client/components/payment-status/payment-status.js:152
 #. failed payment case
 msgid "PAY_GIVE_UP_TXT"
 msgstr ""
 "If you cannot complete the transaction you can either try to get in touch "
 "with your bank or cancel the operation."
 
-#: client/components/payment-status/payment-status.js:116
-#: client/components/payment-status/payment-status.js:152
+#: client/components/payment-status/payment-status.js:125
+#: client/components/payment-status/payment-status.js:158
 msgid "PAY_GIVE_UP_BTN"
 msgstr "Cancel operation and log out"
 
@@ -323,13 +323,13 @@ msgstr "Please enter your new password below."
 
 #: client/components/password-change/password-change.js:143
 #: client/components/password-confirm/password-confirm.js:173
-#: client/components/registration/registration.js:648
+#: client/components/registration/registration.js:646
 msgid "CONFIRM_PWD_LBL"
 msgstr "Confirm password"
 
 #: client/components/password-change/password-change.js:153
 #: client/components/password-confirm/password-confirm.js:184
-#: client/components/registration/registration.js:659
+#: client/components/registration/registration.js:657
 msgid "CONFIRM_PWD_PHOLD"
 msgstr "confirm password"
 
@@ -354,7 +354,7 @@ msgstr "Your new Password"
 msgid "PASSWORD_CHANGE"
 msgstr "Change Password"
 
-#: client/components/organization-wrapper/organization-wrapper.js:297
+#: client/components/organization-wrapper/organization-wrapper.js:306
 #, javascript-format
 msgid "DEFAULT_TITL${ orgName }"
 msgstr "Login to ${ orgName }"
@@ -417,34 +417,34 @@ msgstr "Login again"
 msgid "USERNAME_LOG_TITL"
 msgstr "enter valid email address, an username or a phone number"
 
-#: client/components/login/login.js:375
+#: client/components/login/login.js:374
 msgid "REMEMBER_ME"
 msgstr "remember me on this device"
 
-#: client/components/login/login.js:382
+#: client/components/login/login.js:381
 msgid "LOGIN_ADD_INFO_TXT"
 msgstr ""
 "By logging in, you accept the {terms_and_conditions} and the "
 "{privacy_policy} of this WiFi service. "
 
 #: client/components/login/login.js:52
-#: client/components/login/login.js:393
+#: client/components/login/login.js:392
 msgid "LOGIN"
 msgstr "Log in"
 
-#: client/components/login/login.js:399
+#: client/components/login/login.js:398
 msgid "REGISTER_BTN_LBL"
 msgstr "Not registered yet?"
 
-#: client/components/login/login.js:404
-#: client/components/registration/registration.js:781
+#: client/components/login/login.js:403
+#: client/components/registration/registration.js:779
 msgid "REGISTER_BTN_TXT"
 msgstr "Sign up"
 
 #: client/components/contact-box/contact.js:25
 #: client/components/password-reset/password-reset.js:106
-#: client/components/registration/registration.js:469
-#: client/components/status/status.js:644
+#: client/components/registration/registration.js:467
+#: client/components/status/status.js:668
 msgid "EMAIL"
 msgstr "Email"
 
@@ -478,10 +478,10 @@ msgstr "Change your phone number"
 msgid "CANCEL"
 msgstr "Cancel"
 
-#: client/components/registration/registration.js:516
-#: client/components/registration/registration.js:544
-#: client/components/registration/registration.js:571
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:514
+#: client/components/registration/registration.js:542
+#: client/components/registration/registration.js:569
+#: client/components/registration/registration.js:594
 msgid "OPTIONAL"
 msgstr "optional"
 
@@ -495,8 +495,8 @@ msgstr "Go back to homepage"
 
 #: client/components/login/login.js:220
 #: client/components/registration/registration.js:86
-#: client/components/status/status.js:243
-#: client/components/status/status.js:246
+#: client/components/status/status.js:247
+#: client/components/status/status.js:251
 #: client/utils/handle-logout.js:34
 #: client/utils/validate-token.js:45
 msgid "ERR_OCCUR"
@@ -511,8 +511,8 @@ msgstr "Login error occurred."
 msgid "LOGIN_SUCCESS"
 msgstr "Login successful"
 
-#: client/components/status/status.js:295
-#: client/components/status/status.js:357
+#: client/components/status/status.js:300
+#: client/components/status/status.js:361
 #: client/utils/handle-logout.js:33
 msgid "LOGOUT_SUCCESS"
 msgstr "Logout successful"
@@ -531,7 +531,7 @@ msgstr "An error occurred, the password has not been changed."
 msgid "PWD_CNF_ERR"
 msgstr "The two password fields didn't match."
 
-#: client/components/registration/registration.js:225
+#: client/components/registration/registration.js:222
 msgid "REGISTER_ERR"
 msgstr "Registration error."
 
@@ -545,41 +545,50 @@ msgstr ""
 "Your account has been deactivated. Please contact customer support for more "
 "information."
 
-#: client/components/registration/registration.js:489
+#: client/components/registration/registration.js:487
 msgid "USERNAME_REG_LBL"
 msgstr "Username"
 
-#: client/components/registration/registration.js:502
+#: client/components/registration/registration.js:500
 msgid "USERNAME_REG_PHOLD"
 msgstr "Username"
 
-#: client/components/status/status.js:873
+#: client/components/status/status.js:897
 msgid "CP_LOGIN"
 msgstr ""
 "We are initializing your session in the WiFi service, it may take a few "
 "seconds, please wait ..."
 
-#: client/components/payment-status/payment-status.js:94
+#: client/components/payment-status/payment-status.js:100
 msgid "PAY_REQ"
 msgstr "Payment required to proceed"
 
-#: client/components/payment-status/payment-status.js:106
+#: client/components/payment-status/payment-status.js:115
 msgid "PAY_PROC_BTN"
 msgstr "Proceed with the payment"
 
-#: client/components/payment-status/payment-status.js:97
+#: client/components/payment-status/payment-status.js:105
 #, javascript-format
 msgid "PAY_WARN${ timeout }${ maxAttempts }"
 msgstr ""
-"<p>By clicking on the button below you will be redirected to our "
-"payment gateway service where you can safely use your credit/debit card. "
-"From there you will be redirected to the website of your bank to "
-"confirm the transaction."
-"</p><p>You will have ${ timeout } minutes to complete the process.<br />"
-"<strong>For this reason we recommend preparing your debit/credit "
-"card before initiating the payment process.</strong></p>"
-"<p>If for any reason the process is not completed within the "
-"available time, the internet connection which allows you to "
-"reach the website of your bank will be closed, if this happens "
-"you can just log in again with the credentials you just registered and "
-"repeat the process up a maximum of ${ maxAttempts } times.</p>"
+"<p>By clicking on the button below you will be redirected to our payment "
+"gateway service where you can safely use your credit/debit card. From there "
+"you will be redirected to the website of your bank to confirm the "
+"transaction.</p><p>You will have ${ timeout } minutes to complete the "
+"process.<br /><strong>For this reason we recommend preparing your "
+"debit/credit card before initiating the payment process.</strong></p><p>If "
+"for any reason the process is not completed within the available time, the "
+"internet connection which allows you to reach the website of your bank will "
+"be closed, if this happens you can just log in again with the credentials "
+"you just registered and repeat the process up a maximum of ${ maxAttempts } "
+"times.</p>"
+
+#: client/components/status/status.js:375
+#. wait to trigger login to avoid getting stuck
+#. in captive portal firewall rule reloading
+msgid "PLEASE_WAIT"
+msgstr "Please wait..."
+
+#: client/components/status/status.js:377
+msgid "PLEASE_LOGIN"
+msgstr ""

--- a/i18n/fur.po
+++ b/i18n/fur.po
@@ -22,63 +22,63 @@ msgstr "informativa sul trattamento dei dati personali"
 msgid "TOS_TITL"
 msgstr "termini e le condizioni di utilizzo"
 
-#: client/components/status/status.js:449
-#: client/components/status/status.js:640
+#: client/components/status/status.js:467
+#: client/components/status/status.js:658
 msgid "ACCT_ACTIVE"
 msgstr "Sessione attiva"
 
 #: client/components/logout/logout.js:23
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:265
-#: client/components/status/status.js:473
-#: client/components/status/status.js:554
-#: client/components/status/status.js:736
+#: client/components/status/status.js:491
+#: client/components/status/status.js:572
+#: client/components/status/status.js:754
 msgid "LOGOUT"
 msgstr "Uscire"
 
-#: client/components/status/status.js:632
+#: client/components/status/status.js:650
 msgid "ACCT_START_TIME"
 msgstr "Data/ora inizio"
 
-#: client/components/status/status.js:633
+#: client/components/status/status.js:651
 msgid "ACCT_STOP_TIME"
 msgstr "Data/ora fine"
 
-#: client/components/status/status.js:634
+#: client/components/status/status.js:652
 msgid "ACCT_DURATION"
 msgstr "Durata"
 
-#: client/components/status/status.js:635
+#: client/components/status/status.js:653
 msgid "ACCT_DOWNLOAD"
 msgstr "Traffico download"
 
-#: client/components/status/status.js:636
+#: client/components/status/status.js:654
 msgid "ACCT_UPLOAD"
 msgstr "Traffico Upload"
 
-#: client/components/status/status.js:637
+#: client/components/status/status.js:655
 msgid "ACCT_DEVICE_ADDRESS"
 msgstr "Indirizzo dispositivo"
 
-#: client/components/status/status.js:646
+#: client/components/status/status.js:664
 msgid "STATUS"
 msgstr "Stato"
 
-#: client/components/status/status.js:647
+#: client/components/status/status.js:665
 msgid "LOGGED_IN"
 msgstr "Autenticato"
 
 #: client/components/contact-box/contact.js:25
 #: client/components/password-reset/password-reset.js:106
-#: client/components/registration/registration.js:469
-#: client/components/status/status.js:650
+#: client/components/registration/registration.js:467
+#: client/components/status/status.js:668
 msgid "EMAIL"
 msgstr "Email"
 
-#: client/components/status/status.js:653
+#: client/components/status/status.js:671
 msgid "USERNAME"
 msgstr "Nome utente"
 
-#: client/components/status/status.js:656
+#: client/components/status/status.js:674
 msgid "PHONE_NUMBER"
 msgstr "Numero di telefono"
 
@@ -86,7 +86,7 @@ msgstr "Numero di telefono"
 msgid "STATUS_TITL"
 msgstr "Stato"
 
-#: client/components/status/status.js:684
+#: client/components/status/status.js:702
 msgid "STATUS_CONTENT"
 msgstr ""
 "Login al servizio WiFi effettuato con successo!\n"
@@ -94,25 +94,25 @@ msgstr ""
 "        Lascia questa pagina aperta in caso per poter chiudere la sessione "
 "attiva."
 
-#: client/components/status/status.js:697
+#: client/components/status/status.js:715
 msgid "LOGOUT_MODAL_CONTENT"
 msgstr "Autenticarsi automaticamente la prossima volta?"
 
-#: client/components/status/status.js:705
+#: client/components/status/status.js:723
 msgid "YES"
 msgstr "Sì"
 
-#: client/components/status/status.js:712
+#: client/components/status/status.js:730
 msgid "NO"
 msgstr "No"
 
-#: client/components/registration/registration.js:300
+#: client/components/registration/registration.js:298
 msgid "PLAN_SETTING_TXT"
 msgstr "Seleziona il piano che preferisci"
 
 #: client/components/login/login.js:139
 #: client/components/mobile-phone-change/mobile-phone-change.js:139
-#: client/components/registration/registration.js:392
+#: client/components/registration/registration.js:390
 msgid "PHONE_LBL"
 msgstr "Numero di cellulare"
 
@@ -120,18 +120,18 @@ msgstr "Numero di cellulare"
 #: client/components/login/login.js:172
 #: client/components/mobile-phone-change/mobile-phone-change.js:155
 #: client/components/mobile-phone-change/mobile-phone-change.js:180
-#: client/components/registration/registration.js:416
-#: client/components/registration/registration.js:450
+#: client/components/registration/registration.js:414
+#: client/components/registration/registration.js:448
 msgid "PHONE_PHOLD"
 msgstr "Numero di telefono cellulare"
 
 #: client/components/password-reset/password-reset.js:116
-#: client/components/registration/registration.js:479
+#: client/components/registration/registration.js:477
 msgid "EMAIL_PHOLD"
 msgstr "Indirizzo email"
 
 #: client/components/password-reset/password-reset.js:118
-#: client/components/registration/registration.js:482
+#: client/components/registration/registration.js:480
 msgid "EMAIL_PTRN_DESC"
 msgstr "Indirizzo email valido"
 
@@ -143,140 +143,140 @@ msgstr "Email, numero di telefono o nome utente"
 msgid "USERNAME_LOG_PHOLD"
 msgstr "Email, numero di telefono o nome utente"
 
-#: client/components/registration/registration.js:505
+#: client/components/registration/registration.js:503
 msgid "USERNAME_PTRN_DESC"
 msgstr "Solo lettere, numeri e caratteri speciali @/./+/-/_"
 
-#: client/components/registration/registration.js:515
-#: client/components/registration/registration.js:516
+#: client/components/registration/registration.js:513
+#: client/components/registration/registration.js:514
 msgid "FIRST_NAME_LBL"
 msgstr "Nome"
 
-#: client/components/registration/registration.js:516
-#: client/components/registration/registration.js:544
-#: client/components/registration/registration.js:571
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:514
+#: client/components/registration/registration.js:542
+#: client/components/registration/registration.js:569
+#: client/components/registration/registration.js:594
 msgid "OPTIONAL"
 msgstr "Opzionale"
 
-#: client/components/registration/registration.js:533
+#: client/components/registration/registration.js:531
 msgid "FIRST_NAME_PHOLD"
 msgstr "Nome"
 
-#: client/components/registration/registration.js:543
-#: client/components/registration/registration.js:544
+#: client/components/registration/registration.js:541
+#: client/components/registration/registration.js:542
 msgid "LAST_NAME_LBL"
 msgstr "Cognome"
 
-#: client/components/registration/registration.js:561
+#: client/components/registration/registration.js:559
 msgid "LAST_NAME_PHOLD"
 msgstr "Cognome"
 
-#: client/components/registration/registration.js:570
-#: client/components/registration/registration.js:571
+#: client/components/registration/registration.js:568
+#: client/components/registration/registration.js:569
 msgid "BIRTH_DATE_LBL"
 msgstr "Data di nascita"
 
-#: client/components/registration/registration.js:595
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:593
+#: client/components/registration/registration.js:594
 msgid "LOCATION_LBL"
 msgstr "Indirizzo"
 
-#: client/components/registration/registration.js:611
+#: client/components/registration/registration.js:609
 msgid "LOCATION_PHOLD"
 msgstr "Luogo di residenza"
 
-#: client/components/registration/registration.js:614
+#: client/components/registration/registration.js:612
 msgid "LOCATION_PTRN_DESC"
 msgstr "Solo caratteri, numeri, spazi e punteggiatura"
 
-#: client/components/login/login.js:348
+#: client/components/login/login.js:347
 #: client/components/password-confirm/password-confirm.js:145
-#: client/components/registration/registration.js:620
+#: client/components/registration/registration.js:618
 msgid "PWD_LBL"
 msgstr "Password"
 
-#: client/components/login/login.js:358
+#: client/components/login/login.js:357
 #: client/components/password-confirm/password-confirm.js:156
-#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:628
 msgid "PWD_PHOLD"
 msgstr "Inserisci la password"
 
-#: client/components/login/login.js:360
+#: client/components/login/login.js:359
 #: client/components/password-change/password-change.js:129
 #: client/components/password-change/password-change.js:155
 #: client/components/password-confirm/password-confirm.js:158
 #: client/components/password-confirm/password-confirm.js:186
-#: client/components/registration/registration.js:632
-#: client/components/registration/registration.js:661
+#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:659
 msgid "PWD_PTRN_DESC"
 msgstr "La password deve essere di almeno 6 caratteri"
 
 #: client/components/password-change/password-change.js:143
 #: client/components/password-confirm/password-confirm.js:173
-#: client/components/registration/registration.js:648
+#: client/components/registration/registration.js:646
 msgid "CONFIRM_PWD_LBL"
 msgstr "Conferma password"
 
 #: client/components/password-change/password-change.js:153
 #: client/components/password-confirm/password-confirm.js:184
-#: client/components/registration/registration.js:659
+#: client/components/registration/registration.js:657
 msgid "CONFIRM_PWD_PHOLD"
 msgstr "conferma password"
 
-#: client/components/registration/registration.js:679
+#: client/components/registration/registration.js:677
 msgid "COUNTRY_LBL"
 msgstr "Stato"
 
-#: client/components/registration/registration.js:688
+#: client/components/registration/registration.js:686
 msgid "CITY_LBL"
 msgstr "Cittá"
 
-#: client/components/registration/registration.js:701
+#: client/components/registration/registration.js:699
 msgid "CITY_PHOLD"
 msgstr "Inserisci la città"
 
-#: client/components/registration/registration.js:705
+#: client/components/registration/registration.js:703
 msgid "STREET_LBL"
 msgstr "Indirizzo"
 
-#: client/components/registration/registration.js:718
+#: client/components/registration/registration.js:716
 msgid "STREET_PHOLD"
 msgstr "Inserisci l'indirizzo"
 
-#: client/components/registration/registration.js:722
+#: client/components/registration/registration.js:720
 msgid "ZIP_CODE_LBL"
 msgstr "Codice Avviamento Postale"
 
-#: client/components/registration/registration.js:739
+#: client/components/registration/registration.js:737
 msgid "TAX_NUMBER_LBL"
 msgstr "Codice fiscale o p.IVA"
 
-#: client/components/registration/registration.js:751
+#: client/components/registration/registration.js:749
 msgid "TAX_NUMBER_PHOLD"
 msgstr "Inserisci il codice fiscale o la p.IVA"
 
-#: client/components/registration/registration.js:753
+#: client/components/registration/registration.js:751
 msgid "TAX_NUMBER_PTRN_DESC"
 msgstr "Solo lettere e numeri"
 
-#: client/components/registration/registration.js:768
+#: client/components/registration/registration.js:766
 msgid "REGISTER_ADD_INFO_TXT"
 msgstr ""
 "Compilando ed inviando questo modulo di registrazione, si accettano i "
 "{terms_and_conditions} e l'{privacy_policy} del servizio WiFi."
 
-#: client/components/login/login.js:404
-#: client/components/registration/registration.js:781
+#: client/components/login/login.js:403
+#: client/components/registration/registration.js:779
 msgid "REGISTER_BTN_TXT"
 msgstr "Registrati"
 
-#: client/components/login/login.js:412
-#: client/components/registration/registration.js:794
+#: client/components/login/login.js:411
+#: client/components/registration/registration.js:792
 msgid "FORGOT_PASSWORD"
 msgstr "Password dimenticata?"
 
-#: client/components/registration/registration.js:801
+#: client/components/registration/registration.js:799
 msgid "LINKS_LOGIN_TXT"
 msgstr "Hai già un account? Effettua l'accesso"
 
@@ -284,28 +284,28 @@ msgstr "Hai già un account? Effettua l'accesso"
 msgid "REGISTRATION_TITL"
 msgstr "Registrazione"
 
-#: client/components/payment-status/payment-status.js:137
+#: client/components/payment-status/payment-status.js:143
 #. failed payment case
 msgid "PAY_FAIL"
 msgstr "Pagamento fallito"
 
-#: client/components/payment-status/payment-status.js:138
+#: client/components/payment-status/payment-status.js:144
 #. failed payment case
 msgid "PAY_SUB_H"
 msgstr "Il pagamento non è andato a buon fine."
 
-#: client/components/payment-status/payment-status.js:141
+#: client/components/payment-status/payment-status.js:147
 #. failed payment case
 msgid "PAY_TRY_AGAIN_BTN"
 msgstr "Riprova"
 
-#: client/components/payment-status/payment-status.js:146
+#: client/components/payment-status/payment-status.js:152
 #. failed payment case
 msgid "PAY_GIVE_UP_TXT"
 msgstr "Se la transazione non va a buon fine si prega di contattare il supporto "
 
-#: client/components/payment-status/payment-status.js:119
-#: client/components/payment-status/payment-status.js:152
+#: client/components/payment-status/payment-status.js:125
+#: client/components/payment-status/payment-status.js:158
 msgid "PAY_GIVE_UP_BTN"
 msgstr "Annulla ed esci"
 
@@ -431,7 +431,7 @@ msgid "LOGOUT_CONTENT"
 msgstr "Logout effettuato con successo"
 
 #: client/components/login/login.js:52
-#: client/components/login/login.js:393
+#: client/components/login/login.js:392
 msgid "LOGIN"
 msgstr "Accedi"
 
@@ -445,17 +445,17 @@ msgstr ""
 "Inserisci un indirizzo email valido, un nome utente o un numero di telefono "
 "cellulare"
 
-#: client/components/login/login.js:375
+#: client/components/login/login.js:374
 msgid "REMEMBER_ME"
 msgstr "Ricorda l'accesso su questo dispositivo"
 
-#: client/components/login/login.js:382
+#: client/components/login/login.js:381
 msgid "LOGIN_ADD_INFO_TXT"
 msgstr ""
-"Effettuando il login, dichiari di accettare i {terms_and_conditions} e l'"
-"{privacy_policy} del servizio WiFi."
+"Effettuando il login, dichiari di accettare i {terms_and_conditions} e "
+"l'{privacy_policy} del servizio WiFi."
 
-#: client/components/login/login.js:399
+#: client/components/login/login.js:398
 msgid "REGISTER_BTN_LBL"
 msgstr "Non hai un account?"
 
@@ -479,7 +479,7 @@ msgstr "Non trovato"
 msgid "404_MESSAGE"
 msgstr "Ci scusiamo, la pagina cercata non è stata trovata."
 
-#: client/components/payment-status/payment-status.js:78
+#: client/components/payment-status/payment-status.js:84
 msgid "PAY_SUCCESS"
 msgstr "Il pagamento è stato ricevuto con successo."
 
@@ -493,15 +493,15 @@ msgstr "Torna alla prima pagina"
 
 #: client/components/login/login.js:220
 #: client/components/registration/registration.js:86
-#: client/components/status/status.js:248
-#: client/components/status/status.js:252
+#: client/components/status/status.js:247
+#: client/components/status/status.js:251
 #: client/utils/handle-logout.js:34
 #: client/utils/validate-token.js:45
 msgid "ERR_OCCUR"
 msgstr "Si è verificato un errore!"
 
-#: client/components/status/status.js:301
-#: client/components/status/status.js:363
+#: client/components/status/status.js:300
+#: client/components/status/status.js:361
 #: client/utils/handle-logout.js:33
 msgid "LOGOUT_SUCCESS"
 msgstr "Log out effettuato con successo"
@@ -518,7 +518,7 @@ msgstr "le password non coincidono."
 msgid "REGISTER_SUCCESS"
 msgstr "Registrazione avvenuta con successo"
 
-#: client/components/registration/registration.js:225
+#: client/components/registration/registration.js:222
 msgid "REGISTER_ERR"
 msgstr "Si è verificato un errore durante la registrazione."
 
@@ -541,11 +541,11 @@ msgstr "Il tuo account è stato disattivato. Ti preghiamo di contattare il suppo
 msgid "LOGIN_ERR"
 msgstr "Si è verificato un errore durante l'autenticazione."
 
-#: client/components/registration/registration.js:489
+#: client/components/registration/registration.js:487
 msgid "USERNAME_REG_LBL"
 msgstr "Nome utente"
 
-#: client/components/registration/registration.js:502
+#: client/components/registration/registration.js:500
 msgid "USERNAME_REG_PHOLD"
 msgstr "Nome utente"
 
@@ -554,33 +554,42 @@ msgstr "Nome utente"
 msgid "DEFAULT_TITL${ orgName }"
 msgstr "Accedi a ${ orgName }"
 
-#: client/components/status/status.js:873
+#: client/components/status/status.js:897
 msgid "CP_LOGIN"
 msgstr ""
 "Stiamo inizializzando la tua sessione sul servizio WiFi, potrebbero essere "
 "necessari alcuni secondi, attendere prego..."
 
-#: client/components/payment-status/payment-status.js:94
+#: client/components/payment-status/payment-status.js:100
 msgid "PAY_REQ"
 msgstr "Pagamento richiesto per procedere"
 
-#: client/components/payment-status/payment-status.js:106
+#: client/components/payment-status/payment-status.js:115
 msgid "PAY_PROC_BTN"
 msgstr "Procedi con il pagamento"
 
-#: client/components/payment-status/payment-status.js:97
+#: client/components/payment-status/payment-status.js:105
 #, javascript-format
 msgid "PAY_WARN${ timeout }${ maxAttempts }"
 msgstr ""
-"<p>Cliccando sul pulsante sottostante raggiungerai il "
-"servizio di pagamento dove potrai inserire i dati della tua carta di credito/debito "
-"in totale sicurezza. Dopodichè raggiungerai "
-"il sito web della tua banca per confermare la transazione."
-"</p><p>Avrai a disposizione ${ timeout } minuti per completare il processo.<br />"
-"<strong>Per questo motivo ti consigliamo di preparare la tua carta debito/credito "
-"prima di avviare il processo di pagamento.</strong></p>"
-"<p>Se per qualsiasi motivo il processo non viene completato entro il "
-"tempo disponibile, la connessione internet che ti permette di "
-"raggiungere il sito web della tua banca verrà chiusa, se ciò accade "
-"puoi accedere nuovamente con le credenziali appena registrate e "
+"<p>Cliccando sul pulsante sottostante raggiungerai il servizio di pagamento "
+"dove potrai inserire i dati della tua carta di credito/debito in totale "
+"sicurezza. Dopodichè raggiungerai il sito web della tua banca per "
+"confermare la transazione.</p><p>Avrai a disposizione ${ timeout } minuti "
+"per completare il processo.<br /><strong>Per questo motivo ti consigliamo "
+"di preparare la tua carta debito/credito prima di avviare il processo di "
+"pagamento.</strong></p><p>Se per qualsiasi motivo il processo non viene "
+"completato entro il tempo disponibile, la connessione internet che ti "
+"permette di raggiungere il sito web della tua banca verrà chiusa, se ciò "
+"accade puoi accedere nuovamente con le credenziali appena registrate e "
 "ripetere il processo fino ad un massimo di ${ maxAttempts } volte.</p>"
+
+#: client/components/status/status.js:375
+#. wait to trigger login to avoid getting stuck
+#. in captive portal firewall rule reloading
+msgid "PLEASE_WAIT"
+msgstr "Attendere prego..."
+
+#: client/components/status/status.js:377
+msgid "PLEASE_LOGIN"
+msgstr "Ti preghiamo di accedere"

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -22,63 +22,63 @@ msgstr "informativa sul trattamento dei dati personali"
 msgid "TOS_TITL"
 msgstr "termini e le condizioni di utilizzo"
 
-#: client/components/status/status.js:449
-#: client/components/status/status.js:640
+#: client/components/status/status.js:467
+#: client/components/status/status.js:658
 msgid "ACCT_ACTIVE"
 msgstr "Sessione attiva"
 
 #: client/components/logout/logout.js:23
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:265
-#: client/components/status/status.js:473
-#: client/components/status/status.js:554
-#: client/components/status/status.js:736
+#: client/components/status/status.js:491
+#: client/components/status/status.js:572
+#: client/components/status/status.js:754
 msgid "LOGOUT"
 msgstr "Esci"
 
-#: client/components/status/status.js:632
+#: client/components/status/status.js:650
 msgid "ACCT_START_TIME"
 msgstr "Data/ora inizio"
 
-#: client/components/status/status.js:633
+#: client/components/status/status.js:651
 msgid "ACCT_STOP_TIME"
 msgstr "Data/ora fine"
 
-#: client/components/status/status.js:634
+#: client/components/status/status.js:652
 msgid "ACCT_DURATION"
 msgstr "Durata"
 
-#: client/components/status/status.js:635
+#: client/components/status/status.js:653
 msgid "ACCT_DOWNLOAD"
 msgstr "Traffico download"
 
-#: client/components/status/status.js:636
+#: client/components/status/status.js:654
 msgid "ACCT_UPLOAD"
 msgstr "Traffico Upload"
 
-#: client/components/status/status.js:637
+#: client/components/status/status.js:655
 msgid "ACCT_DEVICE_ADDRESS"
 msgstr "Indirizzo dispositivo"
 
-#: client/components/status/status.js:646
+#: client/components/status/status.js:664
 msgid "STATUS"
 msgstr "Stato"
 
-#: client/components/status/status.js:647
+#: client/components/status/status.js:665
 msgid "LOGGED_IN"
 msgstr "Autenticato"
 
 #: client/components/contact-box/contact.js:25
 #: client/components/password-reset/password-reset.js:106
-#: client/components/registration/registration.js:469
-#: client/components/status/status.js:650
+#: client/components/registration/registration.js:467
+#: client/components/status/status.js:668
 msgid "EMAIL"
 msgstr "Email"
 
-#: client/components/status/status.js:653
+#: client/components/status/status.js:671
 msgid "USERNAME"
 msgstr "Nome utente"
 
-#: client/components/status/status.js:656
+#: client/components/status/status.js:674
 msgid "PHONE_NUMBER"
 msgstr "Numero di telefono"
 
@@ -86,7 +86,7 @@ msgstr "Numero di telefono"
 msgid "STATUS_TITL"
 msgstr "Stato"
 
-#: client/components/status/status.js:684
+#: client/components/status/status.js:702
 msgid "STATUS_CONTENT"
 msgstr ""
 "Login al servizio WiFi effettuato con successo!\n"
@@ -94,25 +94,25 @@ msgstr ""
 "        Lascia questa pagina aperta in caso per poter chiudere la sessione "
 "attiva."
 
-#: client/components/status/status.js:697
+#: client/components/status/status.js:715
 msgid "LOGOUT_MODAL_CONTENT"
 msgstr "Autenticarsi automaticamente la prossima volta?"
 
-#: client/components/status/status.js:705
+#: client/components/status/status.js:723
 msgid "YES"
 msgstr "Sì"
 
-#: client/components/status/status.js:712
+#: client/components/status/status.js:730
 msgid "NO"
 msgstr "No"
 
-#: client/components/registration/registration.js:300
+#: client/components/registration/registration.js:298
 msgid "PLAN_SETTING_TXT"
 msgstr "Seleziona il piano che preferisci"
 
 #: client/components/login/login.js:139
 #: client/components/mobile-phone-change/mobile-phone-change.js:139
-#: client/components/registration/registration.js:392
+#: client/components/registration/registration.js:390
 msgid "PHONE_LBL"
 msgstr "Numero di cellulare"
 
@@ -120,18 +120,18 @@ msgstr "Numero di cellulare"
 #: client/components/login/login.js:172
 #: client/components/mobile-phone-change/mobile-phone-change.js:155
 #: client/components/mobile-phone-change/mobile-phone-change.js:180
-#: client/components/registration/registration.js:416
-#: client/components/registration/registration.js:450
+#: client/components/registration/registration.js:414
+#: client/components/registration/registration.js:448
 msgid "PHONE_PHOLD"
 msgstr "Numero di telefono cellulare"
 
 #: client/components/password-reset/password-reset.js:116
-#: client/components/registration/registration.js:479
+#: client/components/registration/registration.js:477
 msgid "EMAIL_PHOLD"
 msgstr "Indirizzo email"
 
 #: client/components/password-reset/password-reset.js:118
-#: client/components/registration/registration.js:482
+#: client/components/registration/registration.js:480
 msgid "EMAIL_PTRN_DESC"
 msgstr "Indirizzo email valido"
 
@@ -143,140 +143,140 @@ msgstr "Email, numero di telefono o nome utente"
 msgid "USERNAME_LOG_PHOLD"
 msgstr "Email, numero di telefono o nome utente"
 
-#: client/components/registration/registration.js:505
+#: client/components/registration/registration.js:503
 msgid "USERNAME_PTRN_DESC"
 msgstr "Solo lettere, numeri e caratteri speciali @/./+/-/_"
 
-#: client/components/registration/registration.js:515
-#: client/components/registration/registration.js:516
+#: client/components/registration/registration.js:513
+#: client/components/registration/registration.js:514
 msgid "FIRST_NAME_LBL"
 msgstr "Nome"
 
-#: client/components/registration/registration.js:516
-#: client/components/registration/registration.js:544
-#: client/components/registration/registration.js:571
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:514
+#: client/components/registration/registration.js:542
+#: client/components/registration/registration.js:569
+#: client/components/registration/registration.js:594
 msgid "OPTIONAL"
 msgstr "Opzionale"
 
-#: client/components/registration/registration.js:533
+#: client/components/registration/registration.js:531
 msgid "FIRST_NAME_PHOLD"
 msgstr "Nome"
 
-#: client/components/registration/registration.js:543
-#: client/components/registration/registration.js:544
+#: client/components/registration/registration.js:541
+#: client/components/registration/registration.js:542
 msgid "LAST_NAME_LBL"
 msgstr "Cognome"
 
-#: client/components/registration/registration.js:561
+#: client/components/registration/registration.js:559
 msgid "LAST_NAME_PHOLD"
 msgstr "Cognome"
 
-#: client/components/registration/registration.js:570
-#: client/components/registration/registration.js:571
+#: client/components/registration/registration.js:568
+#: client/components/registration/registration.js:569
 msgid "BIRTH_DATE_LBL"
 msgstr "Data di nascita"
 
-#: client/components/registration/registration.js:595
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:593
+#: client/components/registration/registration.js:594
 msgid "LOCATION_LBL"
 msgstr "Indirizzo"
 
-#: client/components/registration/registration.js:611
+#: client/components/registration/registration.js:609
 msgid "LOCATION_PHOLD"
 msgstr "Luogo di residenza"
 
-#: client/components/registration/registration.js:614
+#: client/components/registration/registration.js:612
 msgid "LOCATION_PTRN_DESC"
 msgstr "Solo caratteri, numeri, spazi e punteggiatura"
 
-#: client/components/login/login.js:348
+#: client/components/login/login.js:347
 #: client/components/password-confirm/password-confirm.js:145
-#: client/components/registration/registration.js:620
+#: client/components/registration/registration.js:618
 msgid "PWD_LBL"
 msgstr "Password"
 
-#: client/components/login/login.js:358
+#: client/components/login/login.js:357
 #: client/components/password-confirm/password-confirm.js:156
-#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:628
 msgid "PWD_PHOLD"
 msgstr "Inserisci la password"
 
-#: client/components/login/login.js:360
+#: client/components/login/login.js:359
 #: client/components/password-change/password-change.js:129
 #: client/components/password-change/password-change.js:155
 #: client/components/password-confirm/password-confirm.js:158
 #: client/components/password-confirm/password-confirm.js:186
-#: client/components/registration/registration.js:632
-#: client/components/registration/registration.js:661
+#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:659
 msgid "PWD_PTRN_DESC"
 msgstr "La password deve essere di almeno 6 caratteri"
 
 #: client/components/password-change/password-change.js:143
 #: client/components/password-confirm/password-confirm.js:173
-#: client/components/registration/registration.js:648
+#: client/components/registration/registration.js:646
 msgid "CONFIRM_PWD_LBL"
 msgstr "Conferma password"
 
 #: client/components/password-change/password-change.js:153
 #: client/components/password-confirm/password-confirm.js:184
-#: client/components/registration/registration.js:659
+#: client/components/registration/registration.js:657
 msgid "CONFIRM_PWD_PHOLD"
 msgstr "Conferma password"
 
-#: client/components/registration/registration.js:679
+#: client/components/registration/registration.js:677
 msgid "COUNTRY_LBL"
 msgstr "Stato"
 
-#: client/components/registration/registration.js:688
+#: client/components/registration/registration.js:686
 msgid "CITY_LBL"
 msgstr "Cittá"
 
-#: client/components/registration/registration.js:701
+#: client/components/registration/registration.js:699
 msgid "CITY_PHOLD"
 msgstr "Inserisci la città"
 
-#: client/components/registration/registration.js:705
+#: client/components/registration/registration.js:703
 msgid "STREET_LBL"
 msgstr "Indirizzo"
 
-#: client/components/registration/registration.js:718
+#: client/components/registration/registration.js:716
 msgid "STREET_PHOLD"
 msgstr "Inserisci l'indirizzo"
 
-#: client/components/registration/registration.js:722
+#: client/components/registration/registration.js:720
 msgid "ZIP_CODE_LBL"
 msgstr "Codice Avviamento Postale"
 
-#: client/components/registration/registration.js:739
+#: client/components/registration/registration.js:737
 msgid "TAX_NUMBER_LBL"
 msgstr "Codice fiscale o p.IVA"
 
-#: client/components/registration/registration.js:751
+#: client/components/registration/registration.js:749
 msgid "TAX_NUMBER_PHOLD"
 msgstr "Inserisci il codice fiscale o la p.IVA"
 
-#: client/components/registration/registration.js:753
+#: client/components/registration/registration.js:751
 msgid "TAX_NUMBER_PTRN_DESC"
 msgstr "Solo lettere e numeri"
 
-#: client/components/registration/registration.js:768
+#: client/components/registration/registration.js:766
 msgid "REGISTER_ADD_INFO_TXT"
 msgstr ""
 "Compilando ed inviando questo modulo di registrazione, si accettano i "
 "{terms_and_conditions} e l'{privacy_policy} del servizio WiFi."
 
-#: client/components/login/login.js:404
-#: client/components/registration/registration.js:781
+#: client/components/login/login.js:403
+#: client/components/registration/registration.js:779
 msgid "REGISTER_BTN_TXT"
 msgstr "Registrati"
 
-#: client/components/login/login.js:412
-#: client/components/registration/registration.js:794
+#: client/components/login/login.js:411
+#: client/components/registration/registration.js:792
 msgid "FORGOT_PASSWORD"
 msgstr "Password dimenticata?"
 
-#: client/components/registration/registration.js:801
+#: client/components/registration/registration.js:799
 msgid "LINKS_LOGIN_TXT"
 msgstr "Hai già un account? Effettua l'accesso"
 
@@ -284,28 +284,28 @@ msgstr "Hai già un account? Effettua l'accesso"
 msgid "REGISTRATION_TITL"
 msgstr "Registrazione"
 
-#: client/components/payment-status/payment-status.js:137
+#: client/components/payment-status/payment-status.js:143
 #. failed payment case
 msgid "PAY_FAIL"
 msgstr "Pagamento fallito"
 
-#: client/components/payment-status/payment-status.js:138
+#: client/components/payment-status/payment-status.js:144
 #. failed payment case
 msgid "PAY_SUB_H"
 msgstr "Il pagamento non è andato a buon fine."
 
-#: client/components/payment-status/payment-status.js:141
+#: client/components/payment-status/payment-status.js:147
 #. failed payment case
 msgid "PAY_TRY_AGAIN_BTN"
 msgstr "Riprova"
 
-#: client/components/payment-status/payment-status.js:146
+#: client/components/payment-status/payment-status.js:152
 #. failed payment case
 msgid "PAY_GIVE_UP_TXT"
 msgstr "Se la transazione non va a buon fine si prega di contattare il supporto "
 
-#: client/components/payment-status/payment-status.js:119
-#: client/components/payment-status/payment-status.js:152
+#: client/components/payment-status/payment-status.js:125
+#: client/components/payment-status/payment-status.js:158
 msgid "PAY_GIVE_UP_BTN"
 msgstr "Annulla ed esci"
 
@@ -431,7 +431,7 @@ msgid "LOGOUT_CONTENT"
 msgstr "Logout effettuato con successo"
 
 #: client/components/login/login.js:52
-#: client/components/login/login.js:393
+#: client/components/login/login.js:392
 msgid "LOGIN"
 msgstr "Accedi"
 
@@ -445,17 +445,17 @@ msgstr ""
 "Inserisci un indirizzo email valido, un nome utente o un numero di telefono "
 "cellulare"
 
-#: client/components/login/login.js:375
+#: client/components/login/login.js:374
 msgid "REMEMBER_ME"
 msgstr "Ricorda l'accesso su questo dispositivo"
 
-#: client/components/login/login.js:382
+#: client/components/login/login.js:381
 msgid "LOGIN_ADD_INFO_TXT"
 msgstr ""
-"Effettuando il login, dichiari di accettare i {terms_and_conditions} e l'"
-"{privacy_policy} del servizio WiFi."
+"Effettuando il login, dichiari di accettare i {terms_and_conditions} e "
+"l'{privacy_policy} del servizio WiFi."
 
-#: client/components/login/login.js:399
+#: client/components/login/login.js:398
 msgid "REGISTER_BTN_LBL"
 msgstr "Non hai un account?"
 
@@ -479,7 +479,7 @@ msgstr "Non trovato"
 msgid "404_MESSAGE"
 msgstr "Ci scusiamo, la pagina cercata non è stata trovata."
 
-#: client/components/payment-status/payment-status.js:78
+#: client/components/payment-status/payment-status.js:84
 msgid "PAY_SUCCESS"
 msgstr "Il pagamento è stato ricevuto con successo."
 
@@ -493,15 +493,15 @@ msgstr "Torna alla prima pagina"
 
 #: client/components/login/login.js:220
 #: client/components/registration/registration.js:86
-#: client/components/status/status.js:248
-#: client/components/status/status.js:252
+#: client/components/status/status.js:247
+#: client/components/status/status.js:251
 #: client/utils/handle-logout.js:34
 #: client/utils/validate-token.js:45
 msgid "ERR_OCCUR"
 msgstr "Si è verificato un errore!"
 
-#: client/components/status/status.js:301
-#: client/components/status/status.js:363
+#: client/components/status/status.js:300
+#: client/components/status/status.js:361
 #: client/utils/handle-logout.js:33
 msgid "LOGOUT_SUCCESS"
 msgstr "Log out effettuato con successo"
@@ -518,7 +518,7 @@ msgstr "le password non coincidono."
 msgid "REGISTER_SUCCESS"
 msgstr "Registrazione avvenuta con successo"
 
-#: client/components/registration/registration.js:225
+#: client/components/registration/registration.js:222
 msgid "REGISTER_ERR"
 msgstr "Si è verificato un errore durante la registrazione."
 
@@ -541,11 +541,11 @@ msgstr "Il tuo account è stato disattivato. Ti preghiamo di contattare il suppo
 msgid "LOGIN_ERR"
 msgstr "Si è verificato un errore durante l'autenticazione."
 
-#: client/components/registration/registration.js:489
+#: client/components/registration/registration.js:487
 msgid "USERNAME_REG_LBL"
 msgstr "Nome utente"
 
-#: client/components/registration/registration.js:502
+#: client/components/registration/registration.js:500
 msgid "USERNAME_REG_PHOLD"
 msgstr "Nome utente"
 
@@ -554,33 +554,42 @@ msgstr "Nome utente"
 msgid "DEFAULT_TITL${ orgName }"
 msgstr "Accedi a ${ orgName }"
 
-#: client/components/status/status.js:873
+#: client/components/status/status.js:897
 msgid "CP_LOGIN"
 msgstr ""
 "Stiamo inizializzando la tua sessione sul servizio WiFi, potrebbero essere "
 "necessari alcuni secondi, attendere prego..."
 
-#: client/components/payment-status/payment-status.js:94
+#: client/components/payment-status/payment-status.js:100
 msgid "PAY_REQ"
 msgstr "Pagamento richiesto per procedere"
 
-#: client/components/payment-status/payment-status.js:106
+#: client/components/payment-status/payment-status.js:115
 msgid "PAY_PROC_BTN"
 msgstr "Procedi con il pagamento"
 
-#: client/components/payment-status/payment-status.js:97
+#: client/components/payment-status/payment-status.js:105
 #, javascript-format
 msgid "PAY_WARN${ timeout }${ maxAttempts }"
 msgstr ""
-"<p>Cliccando sul pulsante sottostante raggiungerai il "
-"servizio di pagamento dove potrai inserire i dati della tua carta di credito/debito "
-"in totale sicurezza. Dopodichè raggiungerai "
-"il sito web della tua banca per confermare la transazione."
-"</p><p>Avrai a disposizione ${ timeout } minuti per completare il processo.<br />"
-"<strong>Per questo motivo ti consigliamo di preparare la tua carta debito/credito "
-"prima di avviare il processo di pagamento.</strong></p>"
-"<p>Se per qualsiasi motivo il processo non viene completato entro il "
-"tempo disponibile, la connessione internet che ti permette di "
-"raggiungere il sito web della tua banca verrà chiusa, se ciò accade "
-"puoi accedere nuovamente con le credenziali appena registrate e "
+"<p>Cliccando sul pulsante sottostante raggiungerai il servizio di pagamento "
+"dove potrai inserire i dati della tua carta di credito/debito in totale "
+"sicurezza. Dopodichè raggiungerai il sito web della tua banca per "
+"confermare la transazione.</p><p>Avrai a disposizione ${ timeout } minuti "
+"per completare il processo.<br /><strong>Per questo motivo ti consigliamo "
+"di preparare la tua carta debito/credito prima di avviare il processo di "
+"pagamento.</strong></p><p>Se per qualsiasi motivo il processo non viene "
+"completato entro il tempo disponibile, la connessione internet che ti "
+"permette di raggiungere il sito web della tua banca verrà chiusa, se ciò "
+"accade puoi accedere nuovamente con le credenziali appena registrate e "
 "ripetere il processo fino ad un massimo di ${ maxAttempts } volte.</p>"
+
+#: client/components/status/status.js:375
+#. wait to trigger login to avoid getting stuck
+#. in captive portal firewall rule reloading
+msgid "PLEASE_WAIT"
+msgstr "Attendere prego..."
+
+#: client/components/status/status.js:377
+msgid "PLEASE_LOGIN"
+msgstr "Ti preghiamo di accedere"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -29,63 +29,63 @@ msgstr "Политика конфиденциальности"
 msgid "TOS_TITL"
 msgstr "Условия использования"
 
-#: client/components/status/status.js:449
-#: client/components/status/status.js:640
+#: client/components/status/status.js:467
+#: client/components/status/status.js:658
 msgid "ACCT_ACTIVE"
 msgstr "Активная сессия"
 
 #: client/components/logout/logout.js:23
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:265
-#: client/components/status/status.js:473
-#: client/components/status/status.js:554
-#: client/components/status/status.js:736
+#: client/components/status/status.js:491
+#: client/components/status/status.js:572
+#: client/components/status/status.js:754
 msgid "LOGOUT"
 msgstr "Выйди"
 
-#: client/components/status/status.js:632
+#: client/components/status/status.js:650
 msgid "ACCT_START_TIME"
 msgstr "Дата / время начало"
 
-#: client/components/status/status.js:633
+#: client/components/status/status.js:651
 msgid "ACCT_STOP_TIME"
 msgstr "Дата / время закончено"
 
-#: client/components/status/status.js:634
+#: client/components/status/status.js:652
 msgid "ACCT_DURATION"
 msgstr "Продолжительность"
 
-#: client/components/status/status.js:635
+#: client/components/status/status.js:653
 msgid "ACCT_DOWNLOAD"
 msgstr "Трафик данных довнлоад"
 
-#: client/components/status/status.js:636
+#: client/components/status/status.js:654
 msgid "ACCT_UPLOAD"
 msgstr "Трафик данных аплоад"
 
-#: client/components/status/status.js:637
+#: client/components/status/status.js:655
 msgid "ACCT_DEVICE_ADDRESS"
 msgstr "Адрес устройства"
 
-#: client/components/status/status.js:646
+#: client/components/status/status.js:664
 msgid "STATUS"
 msgstr "Режим"
 
-#: client/components/status/status.js:647
+#: client/components/status/status.js:665
 msgid "LOGGED_IN"
 msgstr "Аутентифицирован"
 
 #: client/components/contact-box/contact.js:25
 #: client/components/password-reset/password-reset.js:106
-#: client/components/registration/registration.js:469
-#: client/components/status/status.js:650
+#: client/components/registration/registration.js:467
+#: client/components/status/status.js:668
 msgid "EMAIL"
 msgstr "Емейл"
 
-#: client/components/status/status.js:653
+#: client/components/status/status.js:671
 msgid "USERNAME"
 msgstr "Имя пользователя"
 
-#: client/components/status/status.js:656
+#: client/components/status/status.js:674
 msgid "PHONE_NUMBER"
 msgstr "Номер телефона"
 
@@ -93,31 +93,31 @@ msgstr "Номер телефона"
 msgid "STATUS_TITL"
 msgstr "Режим"
 
-#: client/components/status/status.js:684
+#: client/components/status/status.js:702
 msgid "STATUS_CONTENT"
 msgstr ""
 "Вход выполнен успешно\n"
 "        Теперь вы можете путешествовать по Интернету"
 
-#: client/components/status/status.js:697
+#: client/components/status/status.js:715
 msgid "LOGOUT_MODAL_CONTENT"
 msgstr "Вы хотите в следующий раз пройти автоматическую аутентификацию?"
 
-#: client/components/status/status.js:705
+#: client/components/status/status.js:723
 msgid "YES"
 msgstr "Да"
 
-#: client/components/status/status.js:712
+#: client/components/status/status.js:730
 msgid "NO"
 msgstr "Нет"
 
-#: client/components/registration/registration.js:300
+#: client/components/registration/registration.js:298
 msgid "PLAN_SETTING_TXT"
 msgstr "Выберите предпочитаемый тип подписки"
 
 #: client/components/login/login.js:139
 #: client/components/mobile-phone-change/mobile-phone-change.js:139
-#: client/components/registration/registration.js:392
+#: client/components/registration/registration.js:390
 msgid "PHONE_LBL"
 msgstr "Номер мобильного телефона"
 
@@ -125,18 +125,18 @@ msgstr "Номер мобильного телефона"
 #: client/components/login/login.js:172
 #: client/components/mobile-phone-change/mobile-phone-change.js:155
 #: client/components/mobile-phone-change/mobile-phone-change.js:180
-#: client/components/registration/registration.js:416
-#: client/components/registration/registration.js:450
+#: client/components/registration/registration.js:414
+#: client/components/registration/registration.js:448
 msgid "PHONE_PHOLD"
 msgstr "Номер телефона"
 
 #: client/components/password-reset/password-reset.js:116
-#: client/components/registration/registration.js:479
+#: client/components/registration/registration.js:477
 msgid "EMAIL_PHOLD"
 msgstr "емайл адрес"
 
 #: client/components/password-reset/password-reset.js:118
-#: client/components/registration/registration.js:482
+#: client/components/registration/registration.js:480
 msgid "EMAIL_PTRN_DESC"
 msgstr "Действующий емейл адрес"
 
@@ -148,140 +148,140 @@ msgstr "Емейл, номер телефона или имя пользоват
 msgid "USERNAME_LOG_PHOLD"
 msgstr "Емейл, номер телефона или имя пользователя"
 
-#: client/components/registration/registration.js:505
+#: client/components/registration/registration.js:503
 msgid "USERNAME_PTRN_DESC"
 msgstr "Только буквы, цифры и символы @/./+/-/_ "
 
-#: client/components/registration/registration.js:515
-#: client/components/registration/registration.js:516
+#: client/components/registration/registration.js:513
+#: client/components/registration/registration.js:514
 msgid "FIRST_NAME_LBL"
 msgstr "Имя"
 
-#: client/components/registration/registration.js:516
-#: client/components/registration/registration.js:544
-#: client/components/registration/registration.js:571
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:514
+#: client/components/registration/registration.js:542
+#: client/components/registration/registration.js:569
+#: client/components/registration/registration.js:594
 msgid "OPTIONAL"
 msgstr "Необязательно"
 
-#: client/components/registration/registration.js:533
+#: client/components/registration/registration.js:531
 msgid "FIRST_NAME_PHOLD"
 msgstr "Имя"
 
-#: client/components/registration/registration.js:543
-#: client/components/registration/registration.js:544
+#: client/components/registration/registration.js:541
+#: client/components/registration/registration.js:542
 msgid "LAST_NAME_LBL"
 msgstr "Фамилия"
 
-#: client/components/registration/registration.js:561
+#: client/components/registration/registration.js:559
 msgid "LAST_NAME_PHOLD"
 msgstr "Фамилия"
 
-#: client/components/registration/registration.js:570
-#: client/components/registration/registration.js:571
+#: client/components/registration/registration.js:568
+#: client/components/registration/registration.js:569
 msgid "BIRTH_DATE_LBL"
 msgstr "Ваш дата рождения"
 
-#: client/components/registration/registration.js:595
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:593
+#: client/components/registration/registration.js:594
 msgid "LOCATION_LBL"
 msgstr "Адрес"
 
-#: client/components/registration/registration.js:611
+#: client/components/registration/registration.js:609
 msgid "LOCATION_PHOLD"
 msgstr "Место жительства"
 
-#: client/components/registration/registration.js:614
+#: client/components/registration/registration.js:612
 msgid "LOCATION_PTRN_DESC"
 msgstr "Только буквы, цифры, пробелы, знаки препинания"
 
-#: client/components/login/login.js:348
+#: client/components/login/login.js:347
 #: client/components/password-confirm/password-confirm.js:145
-#: client/components/registration/registration.js:620
+#: client/components/registration/registration.js:618
 msgid "PWD_LBL"
 msgstr "Пароль"
 
-#: client/components/login/login.js:358
+#: client/components/login/login.js:357
 #: client/components/password-confirm/password-confirm.js:156
-#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:628
 msgid "PWD_PHOLD"
 msgstr "Введите пароль"
 
-#: client/components/login/login.js:360
+#: client/components/login/login.js:359
 #: client/components/password-change/password-change.js:129
 #: client/components/password-change/password-change.js:155
 #: client/components/password-confirm/password-confirm.js:158
 #: client/components/password-confirm/password-confirm.js:186
-#: client/components/registration/registration.js:632
-#: client/components/registration/registration.js:661
+#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:659
 msgid "PWD_PTRN_DESC"
 msgstr "Пароль не менее 6 символов"
 
 #: client/components/password-change/password-change.js:143
 #: client/components/password-confirm/password-confirm.js:173
-#: client/components/registration/registration.js:648
+#: client/components/registration/registration.js:646
 msgid "CONFIRM_PWD_LBL"
 msgstr "Подтвердите пароль"
 
 #: client/components/password-change/password-change.js:153
 #: client/components/password-confirm/password-confirm.js:184
-#: client/components/registration/registration.js:659
+#: client/components/registration/registration.js:657
 msgid "CONFIRM_PWD_PHOLD"
 msgstr "Подтвердите пароль"
 
-#: client/components/registration/registration.js:679
+#: client/components/registration/registration.js:677
 msgid "COUNTRY_LBL"
 msgstr "Страна"
 
-#: client/components/registration/registration.js:688
+#: client/components/registration/registration.js:686
 msgid "CITY_LBL"
 msgstr "Город"
 
-#: client/components/registration/registration.js:701
+#: client/components/registration/registration.js:699
 msgid "CITY_PHOLD"
 msgstr "Введите город"
 
-#: client/components/registration/registration.js:705
+#: client/components/registration/registration.js:703
 msgid "STREET_LBL"
 msgstr "Улица"
 
-#: client/components/registration/registration.js:718
+#: client/components/registration/registration.js:716
 msgid "STREET_PHOLD"
 msgstr "Введите адрес"
 
-#: client/components/registration/registration.js:722
+#: client/components/registration/registration.js:720
 msgid "ZIP_CODE_LBL"
 msgstr "Почтовый Код"
 
-#: client/components/registration/registration.js:739
+#: client/components/registration/registration.js:737
 msgid "TAX_NUMBER_LBL"
 msgstr "Фискальный Код"
 
-#: client/components/registration/registration.js:751
+#: client/components/registration/registration.js:749
 msgid "TAX_NUMBER_PHOLD"
 msgstr "Введите Фискальный Код"
 
-#: client/components/registration/registration.js:753
+#: client/components/registration/registration.js:751
 msgid "TAX_NUMBER_PTRN_DESC"
 msgstr "Только буквы и цифры"
 
-#: client/components/registration/registration.js:768
+#: client/components/registration/registration.js:766
 msgid "REGISTER_ADD_INFO_TXT"
 msgstr ""
 "Заполнив и отправив эту форму, вы принимаете {terms_and_conditions} и "
 "{privacy_policy} этого Wi-Fi сервис"
 
-#: client/components/login/login.js:404
-#: client/components/registration/registration.js:781
+#: client/components/login/login.js:403
+#: client/components/registration/registration.js:779
 msgid "REGISTER_BTN_TXT"
 msgstr "Регистрация"
 
-#: client/components/login/login.js:412
-#: client/components/registration/registration.js:794
+#: client/components/login/login.js:411
+#: client/components/registration/registration.js:792
 msgid "FORGOT_PASSWORD"
 msgstr "Забыл пароль?"
 
-#: client/components/registration/registration.js:801
+#: client/components/registration/registration.js:799
 msgid "LINKS_LOGIN_TXT"
 msgstr "У вас уже есть аккаунт? Войдите"
 
@@ -289,23 +289,23 @@ msgstr "У вас уже есть аккаунт? Войдите"
 msgid "REGISTRATION_TITL"
 msgstr "Регистрация"
 
-#: client/components/payment-status/payment-status.js:138
+#: client/components/payment-status/payment-status.js:144
 #. failed payment case
 msgid "PAY_SUB_H"
 msgstr "Платеж не прошёл"
 
-#: client/components/payment-status/payment-status.js:141
+#: client/components/payment-status/payment-status.js:147
 #. failed payment case
 msgid "PAY_TRY_AGAIN_BTN"
 msgstr "Попробуйте снова"
 
-#: client/components/payment-status/payment-status.js:146
+#: client/components/payment-status/payment-status.js:152
 #. failed payment case
 msgid "PAY_GIVE_UP_TXT"
 msgstr "В случае возникновения проблем обращайтесь в сервис"
 
-#: client/components/payment-status/payment-status.js:119
-#: client/components/payment-status/payment-status.js:152
+#: client/components/payment-status/payment-status.js:125
+#: client/components/payment-status/payment-status.js:158
 msgid "PAY_GIVE_UP_BTN"
 msgstr "Отменить и выйти"
 
@@ -430,7 +430,7 @@ msgid "LOGOUT_CONTENT"
 msgstr "Успешный выход"
 
 #: client/components/login/login.js:52
-#: client/components/login/login.js:393
+#: client/components/login/login.js:392
 msgid "LOGIN"
 msgstr "Войти"
 
@@ -442,17 +442,17 @@ msgstr "Войти снова "
 msgid "USERNAME_LOG_TITL"
 msgstr "Введите действующий адрес емейл, имя пользователя или номер телефона"
 
-#: client/components/login/login.js:375
+#: client/components/login/login.js:374
 msgid "REMEMBER_ME"
 msgstr "Запомни меня на этом устройстве"
 
-#: client/components/login/login.js:382
+#: client/components/login/login.js:381
 msgid "LOGIN_ADD_INFO_TXT"
 msgstr ""
 "Авторизуясь, вы принимаете {terms_and_conditions} и {privacy_policy} этого "
 "сервис"
 
-#: client/components/login/login.js:399
+#: client/components/login/login.js:398
 msgid "REGISTER_BTN_LBL"
 msgstr "Нет аккаунта? "
 
@@ -476,7 +476,7 @@ msgstr " 404 Не найдено"
 msgid "404_MESSAGE"
 msgstr "404 Страница не найдена.."
 
-#: client/components/payment-status/payment-status.js:78
+#: client/components/payment-status/payment-status.js:84
 msgid "PAY_SUCCESS"
 msgstr "Оплачено"
 
@@ -490,15 +490,15 @@ msgstr "Вернись на первую страницу"
 
 #: client/components/login/login.js:220
 #: client/components/registration/registration.js:86
-#: client/components/status/status.js:248
-#: client/components/status/status.js:252
+#: client/components/status/status.js:247
+#: client/components/status/status.js:251
 #: client/utils/handle-logout.js:34
 #: client/utils/validate-token.js:45
 msgid "ERR_OCCUR"
 msgstr "Была ошибка!"
 
-#: client/components/status/status.js:301
-#: client/components/status/status.js:363
+#: client/components/status/status.js:300
+#: client/components/status/status.js:361
 #: client/utils/handle-logout.js:33
 msgid "LOGOUT_SUCCESS"
 msgstr "Успешный выход"
@@ -515,7 +515,7 @@ msgstr "Два пароля не совпадают"
 msgid "REGISTER_SUCCESS"
 msgstr "Успешная регистрация"
 
-#: client/components/registration/registration.js:225
+#: client/components/registration/registration.js:222
 msgid "REGISTER_ERR"
 msgstr "При регистрации произошла ошибка"
 
@@ -538,46 +538,55 @@ msgstr "Ваш аккаунт было деактивирован"
 msgid "LOGIN_ERR"
 msgstr "При аутентификации произошла ошибка"
 
-#: client/components/registration/registration.js:489
+#: client/components/registration/registration.js:487
 msgid "USERNAME_REG_LBL"
 msgstr "Имя пользователя"
 
-#: client/components/registration/registration.js:502
+#: client/components/registration/registration.js:500
 msgid "USERNAME_REG_PHOLD"
 msgstr "Имя пользователя"
 
-#: client/components/status/status.js:879
+#: client/components/status/status.js:897
 msgid "CP_LOGIN"
 msgstr ""
 "We are initializing your session in the WiFi service, it may take a few "
 "seconds, please wait ..."
 
-#: client/components/payment-status/payment-status.js:94
+#: client/components/payment-status/payment-status.js:100
 msgid "PAY_REQ"
 msgstr "Payment required to proceed"
 
-#: client/components/payment-status/payment-status.js:99
+#: client/components/payment-status/payment-status.js:105
 #, javascript-format
 msgid "PAY_WARN${ timeout }${ maxAttempts }"
 msgstr ""
-"<p>By clicking on the button below you will be redirected to our "
-"payment gateway service where you can safely use your credit/debit card. "
-"From there you will be redirected to the website of your bank to "
-"confirm the transaction."
-"</p><p>You will have ${ timeout } minutes to complete the process.<br />"
-"<strong>For this reason we recommend preparing your debit/credit "
-"card before initiating the payment process.</strong></p>"
-"<p>If for any reason the process is not completed within the "
-"available time, the internet connection which allows you to "
-"reach the website of your bank will be closed, if this happens "
-"you can just log in again with the credentials you just registered and "
-"repeat the process up a maximum of ${ maxAttempts } times.</p>"
+"<p>By clicking on the button below you will be redirected to our payment "
+"gateway service where you can safely use your credit/debit card. From there "
+"you will be redirected to the website of your bank to confirm the "
+"transaction.</p><p>You will have ${ timeout } minutes to complete the "
+"process.<br /><strong>For this reason we recommend preparing your "
+"debit/credit card before initiating the payment process.</strong></p><p>If "
+"for any reason the process is not completed within the available time, the "
+"internet connection which allows you to reach the website of your bank will "
+"be closed, if this happens you can just log in again with the credentials "
+"you just registered and repeat the process up a maximum of ${ maxAttempts } "
+"times.</p>"
 
-#: client/components/payment-status/payment-status.js:109
+#: client/components/payment-status/payment-status.js:115
 msgid "PAY_PROC_BTN"
 msgstr "Proceed with the payment"
 
-#: client/components/payment-status/payment-status.js:137
+#: client/components/payment-status/payment-status.js:143
 #. failed payment case
 msgid "PAY_FAIL"
 msgstr "Payment Failed"
+
+#: client/components/status/status.js:375
+#. wait to trigger login to avoid getting stuck
+#. in captive portal firewall rule reloading
+msgid "PLEASE_WAIT"
+msgstr "Подождите пожалуйста..."
+
+#: client/components/status/status.js:377
+msgid "PLEASE_LOGIN"
+msgstr "Пожалуйста, войдите"

--- a/i18n/sl.po
+++ b/i18n/sl.po
@@ -22,8 +22,8 @@ msgstr "politika zasebnosti"
 msgid "TOS_TITL"
 msgstr "pogoji in določila"
 
-#: client/components/status/status.js:443
-#: client/components/status/status.js:634
+#: client/components/status/status.js:467
+#: client/components/status/status.js:658
 msgid "ACCT_ACTIVE"
 msgstr "seja je aktivna"
 
@@ -31,59 +31,59 @@ msgstr "seja je aktivna"
 msgid "STATUS_TITL"
 msgstr "Stanje"
 
-#: client/components/status/status.js:626
+#: client/components/status/status.js:650
 msgid "ACCT_START_TIME"
 msgstr "Začetni čas"
 
-#: client/components/status/status.js:627
+#: client/components/status/status.js:651
 msgid "ACCT_STOP_TIME"
 msgstr "Čas ustavitve"
 
-#: client/components/status/status.js:628
+#: client/components/status/status.js:652
 msgid "ACCT_DURATION"
 msgstr "Trajanje"
 
-#: client/components/status/status.js:629
+#: client/components/status/status.js:653
 msgid "ACCT_DOWNLOAD"
 msgstr "Prenos"
 
-#: client/components/status/status.js:630
+#: client/components/status/status.js:654
 msgid "ACCT_UPLOAD"
 msgstr "Naloži"
 
-#: client/components/status/status.js:631
+#: client/components/status/status.js:655
 msgid "ACCT_DEVICE_ADDRESS"
 msgstr "Naslov naprave"
 
-#: client/components/status/status.js:641
+#: client/components/status/status.js:665
 msgid "LOGGED_IN"
 msgstr "Prijavljeni"
 
-#: client/components/status/status.js:647
+#: client/components/status/status.js:671
 msgid "USERNAME"
 msgstr "Uporabniško ime"
 
-#: client/components/status/status.js:650
+#: client/components/status/status.js:674
 msgid "PHONE_NUMBER"
 msgstr "Telefonska številka"
 
-#: client/components/status/status.js:678
+#: client/components/status/status.js:702
 msgid "STATUS_CONTENT"
 msgstr ""
 "Prijava v WiFi je uspela!  NZdaj lahko uporabljate internet.  NTo stran "
 "lahko pustite odprto, če se želite odjaviti."
 
-#: client/components/status/status.js:691
+#: client/components/status/status.js:715
 msgid "LOGOUT_MODAL_CONTENT"
 msgstr "Ali se želite naslednjič samodejno prijaviti?"
 
-#: client/components/registration/registration.js:300
+#: client/components/registration/registration.js:298
 msgid "PLAN_SETTING_TXT"
 msgstr "Izberite želeni načrt naročnine"
 
 #: client/components/login/login.js:139
 #: client/components/mobile-phone-change/mobile-phone-change.js:139
-#: client/components/registration/registration.js:392
+#: client/components/registration/registration.js:390
 msgid "PHONE_LBL"
 msgstr "Številka mobilnega telefona"
 
@@ -91,18 +91,18 @@ msgstr "Številka mobilnega telefona"
 #: client/components/login/login.js:172
 #: client/components/mobile-phone-change/mobile-phone-change.js:155
 #: client/components/mobile-phone-change/mobile-phone-change.js:180
-#: client/components/registration/registration.js:416
-#: client/components/registration/registration.js:450
+#: client/components/registration/registration.js:414
+#: client/components/registration/registration.js:448
 msgid "PHONE_PHOLD"
 msgstr "vnesite številko mobilnega telefona"
 
 #: client/components/password-reset/password-reset.js:116
-#: client/components/registration/registration.js:479
+#: client/components/registration/registration.js:477
 msgid "EMAIL_PHOLD"
 msgstr "e -poštni naslov"
 
 #: client/components/password-reset/password-reset.js:118
-#: client/components/registration/registration.js:482
+#: client/components/registration/registration.js:480
 msgid "EMAIL_PTRN_DESC"
 msgstr "vnesite veljaven e -poštni naslov"
 
@@ -114,116 +114,116 @@ msgstr "E -pošta, telefonska številka ali uporabniško ime"
 msgid "USERNAME_LOG_PHOLD"
 msgstr "vnesite e -poštni naslov, telefonsko številko ali uporabniško ime"
 
-#: client/components/registration/registration.js:505
+#: client/components/registration/registration.js:503
 msgid "USERNAME_PTRN_DESC"
 msgstr "samo črke, številke in @/./+/-/_ znaki"
 
-#: client/components/registration/registration.js:515
-#: client/components/registration/registration.js:516
+#: client/components/registration/registration.js:513
+#: client/components/registration/registration.js:514
 msgid "FIRST_NAME_LBL"
 msgstr "Ime"
 
-#: client/components/registration/registration.js:533
+#: client/components/registration/registration.js:531
 msgid "FIRST_NAME_PHOLD"
 msgstr "ime"
 
-#: client/components/registration/registration.js:543
-#: client/components/registration/registration.js:544
+#: client/components/registration/registration.js:541
+#: client/components/registration/registration.js:542
 msgid "LAST_NAME_LBL"
 msgstr "Priimek"
 
-#: client/components/registration/registration.js:561
+#: client/components/registration/registration.js:559
 msgid "LAST_NAME_PHOLD"
 msgstr "priimek"
 
-#: client/components/registration/registration.js:570
-#: client/components/registration/registration.js:571
+#: client/components/registration/registration.js:568
+#: client/components/registration/registration.js:569
 msgid "BIRTH_DATE_LBL"
 msgstr "Datum rojstva"
 
-#: client/components/registration/registration.js:595
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:593
+#: client/components/registration/registration.js:594
 msgid "LOCATION_LBL"
 msgstr "Lokacija"
 
-#: client/components/registration/registration.js:611
+#: client/components/registration/registration.js:609
 msgid "LOCATION_PHOLD"
 msgstr "lokacija"
 
-#: client/components/registration/registration.js:614
+#: client/components/registration/registration.js:612
 msgid "LOCATION_PTRN_DESC"
 msgstr "samo črke, številke, presledki, ločila"
 
-#: client/components/login/login.js:348
+#: client/components/login/login.js:347
 #: client/components/password-confirm/password-confirm.js:145
-#: client/components/registration/registration.js:620
+#: client/components/registration/registration.js:618
 msgid "PWD_LBL"
 msgstr "Geslo"
 
-#: client/components/login/login.js:358
+#: client/components/login/login.js:357
 #: client/components/password-confirm/password-confirm.js:156
-#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:628
 msgid "PWD_PHOLD"
 msgstr "geslo"
 
-#: client/components/login/login.js:360
+#: client/components/login/login.js:359
 #: client/components/password-change/password-change.js:129
 #: client/components/password-change/password-change.js:155
 #: client/components/password-confirm/password-confirm.js:158
 #: client/components/password-confirm/password-confirm.js:186
-#: client/components/registration/registration.js:632
-#: client/components/registration/registration.js:661
+#: client/components/registration/registration.js:630
+#: client/components/registration/registration.js:659
 msgid "PWD_PTRN_DESC"
 msgstr "geslo mora imeti najmanj 6 znakov"
 
-#: client/components/registration/registration.js:679
+#: client/components/registration/registration.js:677
 msgid "COUNTRY_LBL"
 msgstr "Država"
 
-#: client/components/registration/registration.js:688
+#: client/components/registration/registration.js:686
 msgid "CITY_LBL"
 msgstr "Mesto"
 
-#: client/components/registration/registration.js:701
+#: client/components/registration/registration.js:699
 msgid "CITY_PHOLD"
 msgstr "vnesite mesto"
 
-#: client/components/registration/registration.js:705
+#: client/components/registration/registration.js:703
 msgid "STREET_LBL"
 msgstr "Ulica"
 
-#: client/components/registration/registration.js:718
+#: client/components/registration/registration.js:716
 msgid "STREET_PHOLD"
 msgstr "vnesite ulico"
 
-#: client/components/registration/registration.js:722
+#: client/components/registration/registration.js:720
 msgid "ZIP_CODE_LBL"
 msgstr "Poštna številka"
 
-#: client/components/registration/registration.js:739
+#: client/components/registration/registration.js:737
 msgid "TAX_NUMBER_LBL"
 msgstr "Davčna številka"
 
-#: client/components/registration/registration.js:751
+#: client/components/registration/registration.js:749
 msgid "TAX_NUMBER_PHOLD"
 msgstr "vnesite svojo davčno identifikacijsko številko (neobvezno)"
 
-#: client/components/registration/registration.js:753
+#: client/components/registration/registration.js:751
 msgid "TAX_NUMBER_PTRN_DESC"
 msgstr "samo številke in črke"
 
-#: client/components/registration/registration.js:768
+#: client/components/registration/registration.js:766
 msgid "REGISTER_ADD_INFO_TXT"
 msgstr ""
 "S prijavo sprejemate {terms_and_conditions} in {privacy_policy} te storitve "
 "WiFi."
 
-#: client/components/login/login.js:412
-#: client/components/registration/registration.js:794
+#: client/components/login/login.js:411
+#: client/components/registration/registration.js:792
 msgid "FORGOT_PASSWORD"
 msgstr "Ste pozabili geslo?"
 
-#: client/components/registration/registration.js:801
+#: client/components/registration/registration.js:799
 msgid "LINKS_LOGIN_TXT"
 msgstr "Že imate račun? Prijavite se"
 
@@ -231,34 +231,34 @@ msgstr "Že imate račun? Prijavite se"
 msgid "REGISTRATION_TITL"
 msgstr "Prijavite se"
 
-#: client/components/payment-status/payment-status.js:78
+#: client/components/payment-status/payment-status.js:84
 msgid "PAY_SUCCESS"
 msgstr "Plačilo je bilo uspešno prejeto."
 
-#: client/components/payment-status/payment-status.js:137
+#: client/components/payment-status/payment-status.js:143
 #. failed payment case
 msgid "PAY_FAIL"
 msgstr "Plačilo ni uspelo"
 
-#: client/components/payment-status/payment-status.js:138
+#: client/components/payment-status/payment-status.js:144
 #. failed payment case
 msgid "PAY_SUB_H"
 msgstr "Pri plačilu je šlo nekaj narobe."
 
-#: client/components/payment-status/payment-status.js:141
+#: client/components/payment-status/payment-status.js:147
 #. failed payment case
 msgid "PAY_TRY_AGAIN_BTN"
 msgstr "Poskusi znova"
 
-#: client/components/payment-status/payment-status.js:146
+#: client/components/payment-status/payment-status.js:152
 #. failed payment case
 msgid "PAY_GIVE_UP_TXT"
 msgstr ""
 "Če transakcije ne morete dokončati, lahko poskusite stopiti v stikpri banki "
 "ali prekličete operacijo."
 
-#: client/components/payment-status/payment-status.js:119
-#: client/components/payment-status/payment-status.js:152
+#: client/components/payment-status/payment-status.js:125
+#: client/components/payment-status/payment-status.js:158
 msgid "PAY_GIVE_UP_BTN"
 msgstr "Preklic operacije in odjava"
 
@@ -302,13 +302,13 @@ msgstr "Spodaj vnesite novo geslo."
 
 #: client/components/password-change/password-change.js:143
 #: client/components/password-confirm/password-confirm.js:173
-#: client/components/registration/registration.js:648
+#: client/components/registration/registration.js:646
 msgid "CONFIRM_PWD_LBL"
 msgstr "Potrdi geslo"
 
 #: client/components/password-change/password-change.js:153
 #: client/components/password-confirm/password-confirm.js:184
-#: client/components/registration/registration.js:659
+#: client/components/registration/registration.js:657
 msgid "CONFIRM_PWD_PHOLD"
 msgstr "potrdite geslo"
 
@@ -380,22 +380,22 @@ msgstr "Odjava uspešna"
 msgid "USERNAME_LOG_TITL"
 msgstr "vnesite veljaven e -poštni naslov, uporabniško ime ali telefonsko številko"
 
-#: client/components/login/login.js:375
+#: client/components/login/login.js:374
 msgid "REMEMBER_ME"
 msgstr "zapomni si me na tej napravi"
 
-#: client/components/login/login.js:382
+#: client/components/login/login.js:381
 msgid "LOGIN_ADD_INFO_TXT"
 msgstr ""
 "Z prijavo sprejemate {terms_and_conditions} in{privacy_policy} te storitve "
 "WiFi."
 
-#: client/components/login/login.js:399
+#: client/components/login/login.js:398
 msgid "REGISTER_BTN_LBL"
 msgstr "Še niste registrirani?"
 
-#: client/components/login/login.js:404
-#: client/components/registration/registration.js:781
+#: client/components/login/login.js:403
+#: client/components/registration/registration.js:779
 msgid "REGISTER_BTN_TXT"
 msgstr "Prijavite se"
 
@@ -430,8 +430,8 @@ msgstr "Nazaj na domačo stran"
 
 #: client/components/login/login.js:220
 #: client/components/registration/registration.js:86
-#: client/components/status/status.js:243
-#: client/components/status/status.js:246
+#: client/components/status/status.js:247
+#: client/components/status/status.js:251
 #: client/utils/handle-logout.js:34
 #: client/utils/validate-token.js:45
 msgid "ERR_OCCUR"
@@ -446,8 +446,8 @@ msgstr "Prišlo je do napake pri prijavi."
 msgid "LOGIN_SUCCESS"
 msgstr "Prijava uspešna"
 
-#: client/components/status/status.js:295
-#: client/components/status/status.js:357
+#: client/components/status/status.js:300
+#: client/components/status/status.js:361
 #: client/utils/handle-logout.js:33
 msgid "LOGOUT_SUCCESS"
 msgstr "Odjava uspešna"
@@ -466,7 +466,7 @@ msgstr "Prišlo je do napake, geslo ni bilo spremenjeno."
 msgid "PWD_CNF_ERR"
 msgstr "Polji za geslo se ne ujemata."
 
-#: client/components/registration/registration.js:225
+#: client/components/registration/registration.js:222
 msgid "REGISTER_ERR"
 msgstr "Napaka pri registraciji."
 
@@ -482,39 +482,39 @@ msgstr ""
 
 #: client/components/logout/logout.js:23
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:265
-#: client/components/status/status.js:467
-#: client/components/status/status.js:548
-#: client/components/status/status.js:730
+#: client/components/status/status.js:491
+#: client/components/status/status.js:572
+#: client/components/status/status.js:754
 msgid "LOGOUT"
 msgstr "Odjava"
 
-#: client/components/status/status.js:640
+#: client/components/status/status.js:664
 msgid "STATUS"
 msgstr "Stanje"
 
 #: client/components/contact-box/contact.js:25
 #: client/components/password-reset/password-reset.js:106
-#: client/components/registration/registration.js:469
-#: client/components/status/status.js:644
+#: client/components/registration/registration.js:467
+#: client/components/status/status.js:668
 msgid "EMAIL"
 msgstr "E-naslov"
 
-#: client/components/status/status.js:699
+#: client/components/status/status.js:723
 msgid "YES"
 msgstr "Da"
 
-#: client/components/status/status.js:706
+#: client/components/status/status.js:730
 msgid "NO"
 msgstr "Ne"
 
-#: client/components/registration/registration.js:516
-#: client/components/registration/registration.js:544
-#: client/components/registration/registration.js:571
-#: client/components/registration/registration.js:596
+#: client/components/registration/registration.js:514
+#: client/components/registration/registration.js:542
+#: client/components/registration/registration.js:569
+#: client/components/registration/registration.js:594
 msgid "OPTIONAL"
 msgstr "neobvezno"
 
-#: client/components/organization-wrapper/organization-wrapper.js:297
+#: client/components/organization-wrapper/organization-wrapper.js:306
 #, javascript-format
 msgid "DEFAULT_TITL${ orgName }"
 msgstr "Prijava v WiFi"
@@ -532,7 +532,7 @@ msgid "CANCEL"
 msgstr "Prekliči"
 
 #: client/components/login/login.js:52
-#: client/components/login/login.js:393
+#: client/components/login/login.js:392
 msgid "LOGIN"
 msgstr "Vpiši se"
 
@@ -544,27 +544,37 @@ msgstr "Znova se prijavite"
 msgid "HELPDESK"
 msgstr "Pomoč"
 
-#: client/components/registration/registration.js:489
+#: client/components/registration/registration.js:487
 msgid "USERNAME_REG_LBL"
 msgstr "Nutzername"
 
-#: client/components/registration/registration.js:502
+#: client/components/registration/registration.js:500
 msgid "USERNAME_REG_PHOLD"
 msgstr "nutzername"
 
-#: client/components/status/status.js:873
+#: client/components/status/status.js:897
 msgid "CP_LOGIN"
 msgstr "Začenjamo vašo sejo v storitvi WiFi, lahko traja nekaj sekund, počakajte ..."
 
-#: client/components/payment-status/payment-status.js:94
+#: client/components/payment-status/payment-status.js:100
 msgid "PAY_REQ"
 msgstr "Plačilo je potrebno za nadaljevanje"
 
-#: client/components/payment-status/payment-status.js:109
+#: client/components/payment-status/payment-status.js:115
 msgid "PAY_PROC_BTN"
 msgstr "Nadaljujte s plačilom"
 
-#: client/components/payment-status/payment-status.js:99
+#: client/components/payment-status/payment-status.js:105
 #, javascript-format
 msgid "PAY_WARN${ timeout }${ maxAttempts }"
 msgstr ""
+
+#: client/components/status/status.js:375
+#. wait to trigger login to avoid getting stuck
+#. in captive portal firewall rule reloading
+msgid "PLEASE_WAIT"
+msgstr "Prosim počakaj..."
+
+#: client/components/status/status.js:377
+msgid "PLEASE_LOGIN"
+msgstr "Prosim prijavite se"


### PR DESCRIPTION
After captive portal logout on PfSense, any outgoing HTTP request fails
for a few seconds.

For this reason we should avoid to lazily import Login, which can
get downloaded again and cause the logout process to hang.

Moreover, for the reasons above, during credit/debit card
payment/verification we cannot automatically log out and log in
the user, therefore we shall force a logout and ask the user
to log in after successful registration and payment.

Some informational toast messages with long autoClose have been
added to deal with the cases in which the wait time may last
for many seconds.

Closes #410