### PR TITLE
[fix] Fixed children with same key error when past sessions load #420

### DIFF
--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -229,7 +229,8 @@ export default class Status extends React.Component {
         options.sessionsToLogout = response.data;
       } else {
         const {pastSessions} = this.state;
-        options.pastSessions = pastSessions.concat(response.data);
+        options.pastSessions =
+          para.page === 1 ? response.data : pastSessions.concat(response.data);
         options.currentPage = params.page;
       }
       options.hasMoreSessions =

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1385,4 +1385,39 @@ describe("<Status /> interactions", () => {
     expect(toast.error).not.toHaveBeenCalled();
     expect(logError).toHaveBeenCalledWith(response, "Error occurred!");
   });
+  it("should not concat same past session again", async () => {
+    const data = [
+      {
+        session_id: 1,
+        start_time: "2020-09-08T00:22:28-04:00",
+        stop_time: "2020-09-08T00:22:29-04:00",
+      },
+    ];
+    axios
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          statusText: "OK",
+          data,
+          headers: {},
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.resolve({
+          status: 200,
+          statusText: "OK",
+          data,
+          headers: {},
+        }),
+      );
+    const prop = createTestProps();
+    wrapper = shallow(<Status {...prop} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    await wrapper.instance().getUserPassedRadiusSessions();
+    expect(wrapper.instance().state.pastSessions).toEqual(data);
+    await wrapper.instance().getUserPassedRadiusSessions();
+    expect(wrapper.instance().state.pastSessions).toEqual(data);
+  });
 });


### PR DESCRIPTION
Changed the concat code when page is 1 because due to internal state change it may
be possible that sessions will be fetched again for same page.

Fixes #420