### PR TITLE
[fix] Fixed "bank_card" redirects from status page #494

### DIFF
--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -196,7 +196,7 @@ export default class Status extends React.Component {
     // if the user needs bank card verification,
     // redirect to payment page and stop here
     if (needsVerify("bank_card", userData, settings)) {
-      history.push(`/${orgSlug}/payment/process`);
+      history.push(`/${orgSlug}/payment/draft`);
       return;
     }
 

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -850,7 +850,7 @@ describe("<Status /> interactions", () => {
 
     // ensure user is redirected to payment URL
     expect(history.push).toHaveBeenCalledWith(
-      `/${props.orgSlug}/payment/process`,
+      `/${props.orgSlug}/payment/draft`,
     );
     // ensure sessions are not fetched
     expect(Status.prototype.getUserActiveRadiusSessions).not.toHaveBeenCalled();
@@ -904,7 +904,7 @@ describe("<Status /> interactions", () => {
 
     // ensure user is redirected to payment URL
     expect(history.push).toHaveBeenCalledWith(
-      `/${props.orgSlug}/payment/process`,
+      `/${props.orgSlug}/payment/draft`,
     );
     // ensure sessions are not fetched
     expect(Status.prototype.getUserActiveRadiusSessions).not.toHaveBeenCalled();


### PR DESCRIPTION
Status page will redirect to the draft payment page
(/<org-slug>/payment/draft) instead of payment process page.

Users should be always greeted by  payment instructions before
continuing with the payment.

Closes #494