### PR TITLE
[fix] Fixed status CSS quirks

### DIFF
--- a/client/components/status/__snapshots__/status.test.js.snap
+++ b/client/components/status/__snapshots__/status.test.js.snap
@@ -42,7 +42,9 @@ exports[`<Status /> rendering should render correctly 1`] = `
           >
             You may leave this page open in case you want to log out.
           </p>
-          <p>
+          <p
+            className="status-content"
+          >
             <label>
               Status
               :
@@ -183,7 +185,9 @@ exports[`<Status /> rendering with placeholder translation tags should render tr
           >
             STATUS_CONTENT
           </p>
-          <p>
+          <p
+            className="status-content"
+          >
             <label>
               STATUS
               :

--- a/client/components/status/index.css
+++ b/client/components/status/index.css
@@ -57,17 +57,27 @@
 }
 #sessions {
   flex-grow: 1;
-  justify-content: center;
   max-width: 1000px;
   margin: 0 auto;
 }
 #sessions > div {
   width: 100%;
 }
+#status .status-content {
+  line-height: 22px;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+}
 
 @media screen and (min-width: 0px) and (max-width: 500px) {
   .logout-modal-container p.message {
     margin: 0 6%;
     line-height: 30px;
+  }
+  .status-content p {
+    min-width: 373px;
+  }
+  .status-content label {
+    margin-right: 0.4em;
   }
 }

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -783,7 +783,7 @@ export default class Status extends React.Component {
                     return null;
                   })}
                 {Object.keys(userInfo).map((key) => (
-                  <p key={key}>
+                  <p key={key} className="status-content">
                     <label>{user_info[key].text}:</label>
                     <span>{userInfo[key]}</span>
                   </p>


### PR DESCRIPTION
- break long emails and avoid layout break
- position session list at top of its box