### PR TITLE
[change] Select toast level based on payment status

### DIFF
--- a/client/utils/get-payment-status.js
+++ b/client/utils/get-payment-status.js
@@ -18,7 +18,11 @@ export const getPaymentStatus = async (orgSlug, paymentId, tokenInfo) => {
     });
     if (response.status === 200) {
       if (response.data.message) {
-        toast.error(response.data.message);
+        if (response.data.status === "failed") {
+          toast.error(response.data.message);
+        } else {
+          toast.info(response.data.message);
+        }
       }
       return response.data.status;
     }

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -783,12 +783,14 @@ describe("getPaymentStatusRedirectUrl tests", () => {
   });
   it("should return success URL if payment status is success", async () => {
     const {orgSlug, paymentId, tokenInfo, setUserData, userData} = getArgs();
+    const infoToast = jest.spyOn(dependency.toast, "info");
     axios.mockImplementationOnce(() =>
       Promise.resolve({
         status: 200,
         statusText: "OK",
         data: {
           status: "success",
+          message: "Payment succeeded",
         },
       }),
     );
@@ -806,6 +808,8 @@ describe("getPaymentStatusRedirectUrl tests", () => {
       mustLogin: true,
       payment_url: null,
     });
+    expect(infoToast).toHaveBeenCalledTimes(1);
+    expect(infoToast).toHaveBeenCalledWith("Payment succeeded");
   });
   it("should return failure URL if payment status is failed", async () => {
     const {orgSlug, paymentId, tokenInfo, setUserData, userData} = getArgs();


### PR DESCRIPTION
The `getPaymentStatus` would use toast.error if the response included  "error" payment status. It would use toast.info otherwise.