### PR TITLE
[bug] Hide empty usage box when RadiusGroup has no checks #819

### DIFF
--- a/client/components/registration/registration.test.js
+++ b/client/components/registration/registration.test.js
@@ -30,6 +30,7 @@ const createTestProps = (props, configName = "default") => {
   const config = getConfig(configName);
   return {
     language: "en",
+    defaultLanguage: "en",
     orgSlug: configName,
     orgName: config.name,
     settings: config.settings,
@@ -54,7 +55,9 @@ const responseData = {
 };
 
 describe("<Registration /> rendering with placeholder translation tags", () => {
-  const props = createTestProps();
+  const props = createTestProps({
+    defaultLanguage: "en",
+  });
   const wrapper = shallow(<Registration {...props} />, {
     context: loadingContextValue,
   });

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -340,35 +340,42 @@ export default class Status extends React.Component {
     const options = {radiusUsageSpinner: false};
     let isPlanExhausted = false;
     try {
-      const response = await axios({
-        method: "get",
-        headers: {
-          "content-type": "application/x-www-form-urlencoded",
-          Authorization: `Bearer ${userData.auth_token}`,
-        },
-        url,
-      });
-      options.userChecks = response.data.checks;
-      if (options.userChecks) {
-        options.userChecks.forEach((check) => {
-          if (check.value === String(check.result)) {
-            isPlanExhausted = true;
-          }
-        });
-      }
-      if (planExhausted !== isPlanExhausted) {
-        setPlanExhausted(isPlanExhausted);
-        if (isPlanExhausted) {
-          toast.info(t`PLAN_EXHAUSTED_TOAST`);
-        }
-      }
-      if (response.data.plan) {
-        options.userPlan = response.data.plan;
-      }
-      if (!showRadiusUsage) {
-        options.showRadiusUsage = true;
-      }
-      this.setState(options);
+     const response = await axios({
+       method: "get",
+       headers: {
+         "content-type": "application/x-www-form-urlencoded",
+         Authorization: `Bearer ${userData.auth_token}`,
+       },
+       url,
+     });
+
+     // Only set userChecks if checks array exists and is not empty
+     if (response.data.checks && response.data.checks.length > 0) {
+       options.userChecks = response.data.checks;
+       options.userChecks.forEach((check) => {
+         if (check.value === String(check.result)) {
+           isPlanExhausted = true;
+         }
+       });
+
+       if (planExhausted !== isPlanExhausted) {
+         setPlanExhausted(isPlanExhausted);
+         if (isPlanExhausted) {
+           toast.info(t`PLAN_EXHAUSTED_TOAST`);
+         }
+       }
+
+       // Only enable radius usage display if we have checks
+       if (!showRadiusUsage) {
+         options.showRadiusUsage = true;
+       }
+     }
+
+     if (response.data.plan) {
+       options.userPlan = response.data.plan;
+     }
+
+     this.setState(options);
     } catch (error) {
       // logout only if unauthorized or forbidden
       if (error.response) {


### PR DESCRIPTION
## Checklist

- [X] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [X] I have manually tested the changes proposed in this pull request.
- [X] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #819 .

## Description of Changes

Fixed an issue where an empty box was being displayed in the status page when a user's RadiusGroup had no defined checks. For example, when a user belonged to the `power-users` group which doesn't define any usage checks, an empty box would still appear where usage information should be shown.

## Changes

Modified `client/components/status/status.js` to properly handle cases when the API returns no checks:
- Added check for empty checks array before setting `userChecks`
- Explicitly set `userChecks` to null and disable radius usage display when no checks exist
- Only enable radius usage display when there are actual checks to show

Before this change, even with no checks, the UI would still show an empty box. Now, when a user's RadiusGroup has no checks defined, no empty box will be displayed, providing a cleaner user interface.

## Screenshot

<img width="346" alt="a1" src="https://github.com/user-attachments/assets/d5c7941a-6c8b-47f0-91db-9d6d31434ce3" />
All tests has been passed after changes

@pandafy kindly review this
