### PR TITLE
[ci] Cache python env: use OpenWISP RADIUS commit hash #849

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,16 +84,16 @@ jobs:
 
       - name: Get openwisp-radius
         run: |
-          curl -L https://github.com/openwisp/openwisp-radius/tarball/master \
-               -o openwisp-radius.tar.gz
-          tar -xvzf openwisp-radius.tar.gz && mkdir openwisp-radius
-          mv openwisp-*/* openwisp-radius
+          git clone --depth=1 https://github.com/openwisp/openwisp-radius/ openwisp-radius
+          cd openwisp-radius
+          echo "OpenWISP RADIUS commit: $(git rev-parse HEAD)"
+          echo "OW_RADIUS_VERSION=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
       - name: Cache python environment
         uses: actions/cache@v4
         with:
           path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{secrets.CACHE_VERSION}}-${{ hashFiles('openwisp-radius/setup.py') }}
+          key: ${{ env.pythonLocation }}-${{ env.OW_RADIUS_VERSION }}
 
       - name: Installing OpenWISP Radius
         run: |


### PR DESCRIPTION
Get rid of CACHE_VERSION secret which has to be managed manually.
Let's use the OpenWISP RADIUS commit hash instead.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- N/A I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #849.