### PR TITLE
Automate generation of client/test-translation.json from .po files #902

### DIFF
--- a/client/test-translation.json
+++ b/client/test-translation.json
@@ -12,206 +12,398 @@
       "": {
         "msgid": "",
         "msgstr": [
-          "Content-Type: text/plain; charset=utf-8\nPlural-Forms: nplurals = 2; plural = (n != 1);\nLanguage: en\nmime-version: 1.0\nContent-Transfer-Encoding: 8bit\n"
+          "Language: en\\nMIME-Version: 1.0\\nContent-Type: text/plain; charset=UTF-8\\nContent-Transfer-Encoding: 8bit\\nPlural-Forms: nplurals = 2; plural = (n != 1);\\n"
+        ]
+      },
+      "ERR_OCCUR": {
+        "msgid": "ERR_OCCUR",
+        "msgstr": [
+          "Error occurred!"
+        ]
+      },
+      "PLAN_SETTING_TXT": {
+        "msgid": "PLAN_SETTING_TXT",
+        "msgstr": [
+          "Please select the preferred subscription plan"
+        ]
+      },
+      "LOGOUT_SUCCESS": {
+        "msgid": "LOGOUT_SUCCESS",
+        "msgstr": [
+          "Logout successful"
+        ]
+      },
+      "YES": {
+        "msgid": "YES",
+        "msgstr": [
+          "Yes"
+        ]
+      },
+      "NO": {
+        "msgid": "NO",
+        "msgstr": [
+          "No"
         ]
       },
       "PWD_REVEAL": {
         "msgid": "PWD_REVEAL",
-        "msgstr": ["reveal password"]
+        "msgstr": [
+          "reveal password"
+        ]
       },
       "PWD_HIDE": {
         "msgid": "PWD_HIDE",
-        "msgstr": ["hide password"]
+        "msgstr": [
+          "hide password"
+        ]
       },
       "PRIV_POL_TITL": {
         "msgid": "PRIV_POL_TITL",
-        "msgstr": ["privacy policy"]
+        "msgstr": [
+          "privacy policy"
+        ]
       },
       "TOS_TITL": {
         "msgid": "TOS_TITL",
-        "msgstr": ["terms and conditions"]
+        "msgstr": [
+          "terms and conditions"
+        ]
+      },
+      "PLEASE_WAIT": {
+        "msgid": "PLEASE_WAIT",
+        "msgstr": [
+          "Please wait..."
+        ]
+      },
+      "PLEASE_LOGIN": {
+        "msgid": "PLEASE_LOGIN",
+        "msgstr": [
+          "Please log in"
+        ]
       },
       "ACCT_ACTIVE": {
         "msgid": "ACCT_ACTIVE",
-        "msgstr": ["session is active"]
+        "msgstr": [
+          "session is active"
+        ]
       },
       "LOGOUT": {
         "msgid": "LOGOUT",
-        "msgstr": ["Logout"]
-      },
-      "STATUS_TITL": {
-        "msgid": "STATUS_TITL",
-        "msgstr": ["Status"]
+        "msgstr": [
+          "Logout"
+        ]
       },
       "ACCT_START_TIME": {
         "msgid": "ACCT_START_TIME",
-        "msgstr": ["Start time"]
+        "msgstr": [
+          "Start time"
+        ]
       },
       "ACCT_STOP_TIME": {
         "msgid": "ACCT_STOP_TIME",
-        "msgstr": ["Stop time"]
+        "msgstr": [
+          "Stop time"
+        ]
       },
       "ACCT_DURATION": {
         "msgid": "ACCT_DURATION",
-        "msgstr": ["Duration"]
+        "msgstr": [
+          "Duration"
+        ]
       },
       "ACCT_DOWNLOAD": {
         "msgid": "ACCT_DOWNLOAD",
-        "msgstr": ["Download"]
+        "msgstr": [
+          "Download"
+        ]
       },
       "ACCT_UPLOAD": {
         "msgid": "ACCT_UPLOAD",
-        "msgstr": ["Upload"]
+        "msgstr": [
+          "Upload"
+        ]
       },
       "ACCT_DEVICE_ADDRESS": {
         "msgid": "ACCT_DEVICE_ADDRESS",
-        "msgstr": ["Device address"]
+        "msgstr": [
+          "Device address"
+        ]
       },
       "STATUS": {
         "msgid": "STATUS",
-        "msgstr": ["Status"]
+        "msgstr": [
+          "Status"
+        ]
       },
       "LOGGED_IN": {
         "msgid": "LOGGED_IN",
-        "msgstr": ["Logged in"]
+        "msgstr": [
+          "Logged in"
+        ]
+      },
+      "EMAIL": {
+        "msgid": "EMAIL",
+        "msgstr": [
+          "Email"
+        ]
       },
       "USERNAME": {
         "msgid": "USERNAME",
-        "msgstr": ["Username"]
+        "msgstr": [
+          "Username"
+        ]
       },
       "PHONE_NUMBER": {
         "msgid": "PHONE_NUMBER",
-        "msgstr": ["Phone number"]
+        "msgstr": [
+          "Phone number"
+        ]
+      },
+      "CP_LOGIN": {
+        "msgid": "CP_LOGIN",
+        "msgstr": [
+          "We are initializing your session in the WiFi service, it may take a few seconds, please wait ..."
+        ]
+      },
+      "STATUS_TITL": {
+        "msgid": "STATUS_TITL",
+        "msgstr": [
+          "Status"
+        ]
+      },
+      "PASSWORD_EXPIRED": {
+        "msgid": "PASSWORD_EXPIRED",
+        "msgstr": [
+          "Your password has expired, please update it."
+        ]
+      },
+      "PLAN_EXHAUSTED_TOAST": {
+        "msgid": "PLAN_EXHAUSTED_TOAST",
+        "msgstr": [
+          "You have used all the data in your plan."
+        ]
+      },
+      "SUCCESS_UPGRADE_PLAN": {
+        "msgid": "SUCCESS_UPGRADE_PLAN",
+        "msgstr": [
+          "Plan upgrade in progress"
+        ]
       },
       "STATUS_CONTENT": {
         "msgid": "STATUS_CONTENT",
         "msgstr": [
-          "WiFi Login Successful!\n        You can now use the internet.\n        You may leave this page open in case you want to log out."
+          "WiFi Login Successful!\\n        You can now use the internet.\\n        You may leave this page open in case you want to log out."
+        ]
+      },
+      "TRAFFIC_EXHAUSTED": {
+        "msgid": "TRAFFIC_EXHAUSTED",
+        "msgstr": [
+          "Data limit reached"
         ]
       },
       "LOGOUT_MODAL_CONTENT": {
         "msgid": "LOGOUT_MODAL_CONTENT",
-        "msgstr": ["Do you want to automatically log in the next time?"]
+        "msgstr": [
+          "Do you want to automatically log in the next time?"
+        ]
       },
-      "YES": {
-        "msgid": "YES",
-        "msgstr": ["Yes"]
+      "CURRENT_SUBSCRIPTION_TXT": {
+        "msgid": "CURRENT_SUBSCRIPTION_TXT",
+        "msgstr": [
+          "Current subscription:"
+        ]
       },
-      "NO": {
-        "msgid": "NO",
-        "msgstr": ["No"]
+      "USAGE_LIMIT_EXHAUSTED_TXT": {
+        "msgid": "USAGE_LIMIT_EXHAUSTED_TXT",
+        "msgstr": [
+          "You have reached your data limit. Please top up your account to continue."
+        ]
       },
-      "PLAN_SETTING_TXT": {
-        "msgid": "PLAN_SETTING_TXT",
-        "msgstr": ["Please select the preferred subscription plan"]
+      "PLAN_UPGRADE_BTN_TXT": {
+        "msgid": "PLAN_UPGRADE_BTN_TXT",
+        "msgstr": [
+          "Top up"
+        ]
       },
       "PHONE_LBL": {
         "msgid": "PHONE_LBL",
-        "msgstr": ["Mobile phone number"]
+        "msgstr": [
+          "Mobile phone number"
+        ]
       },
       "PHONE_PHOLD": {
         "msgid": "PHONE_PHOLD",
-        "msgstr": ["enter mobile phone number"]
+        "msgstr": [
+          "enter mobile phone number"
+        ]
       },
       "EMAIL_PHOLD": {
         "msgid": "EMAIL_PHOLD",
-        "msgstr": ["email address"]
+        "msgstr": [
+          "email address"
+        ]
       },
       "EMAIL_PTRN_DESC": {
         "msgid": "EMAIL_PTRN_DESC",
-        "msgstr": ["enter valid email address"]
+        "msgstr": [
+          "enter valid email address"
+        ]
       },
-      "USERNAME_LOG_LBL": {
-        "msgid": "USERNAME_LOG_LBL",
-        "msgstr": ["Email, phone number or username"]
+      "USERNAME_REG_LBL": {
+        "msgid": "USERNAME_REG_LBL",
+        "msgstr": [
+          "Username"
+        ]
       },
-      "USERNAME_LOG_PHOLD": {
-        "msgid": "USERNAME_LOG_PHOLD",
-        "msgstr": ["enter email, phone number or username"]
+      "USERNAME_REG_PHOLD": {
+        "msgid": "USERNAME_REG_PHOLD",
+        "msgstr": [
+          "Username"
+        ]
       },
       "USERNAME_PTRN_DESC": {
         "msgid": "USERNAME_PTRN_DESC",
-        "msgstr": ["only letters, numbers and @/./+/-/_ characters"]
+        "msgstr": [
+          "only letters, numbers and @/./+/-/_ characters"
+        ]
       },
       "FIRST_NAME_LBL": {
         "msgid": "FIRST_NAME_LBL",
-        "msgstr": ["First name"]
+        "msgstr": [
+          "First name"
+        ]
+      },
+      "OPTIONAL": {
+        "msgid": "OPTIONAL",
+        "msgstr": [
+          "optional"
+        ]
       },
       "FIRST_NAME_PHOLD": {
         "msgid": "FIRST_NAME_PHOLD",
-        "msgstr": ["first name"]
+        "msgstr": [
+          "first name"
+        ]
       },
       "LAST_NAME_LBL": {
         "msgid": "LAST_NAME_LBL",
-        "msgstr": ["Last name"]
+        "msgstr": [
+          "Last name"
+        ]
       },
       "LAST_NAME_PHOLD": {
         "msgid": "LAST_NAME_PHOLD",
-        "msgstr": ["last name"]
+        "msgstr": [
+          "last name"
+        ]
       },
       "BIRTH_DATE_LBL": {
         "msgid": "BIRTH_DATE_LBL",
-        "msgstr": ["Birth date"]
+        "msgstr": [
+          "Birth date"
+        ]
       },
       "LOCATION_LBL": {
         "msgid": "LOCATION_LBL",
-        "msgstr": ["Location"]
+        "msgstr": [
+          "Location"
+        ]
       },
       "LOCATION_PHOLD": {
         "msgid": "LOCATION_PHOLD",
-        "msgstr": ["location"]
+        "msgstr": [
+          "location"
+        ]
       },
       "LOCATION_PTRN_DESC": {
         "msgid": "LOCATION_PTRN_DESC",
-        "msgstr": ["only letters, numbers, spaces, punctuation"]
+        "msgstr": [
+          "only letters, numbers, spaces, punctuation"
+        ]
       },
       "PWD_LBL": {
         "msgid": "PWD_LBL",
-        "msgstr": ["Password"]
+        "msgstr": [
+          "Password"
+        ]
       },
       "PWD_PHOLD": {
         "msgid": "PWD_PHOLD",
-        "msgstr": ["password"]
+        "msgstr": [
+          "password"
+        ]
       },
       "PWD_PTRN_DESC": {
         "msgid": "PWD_PTRN_DESC",
-        "msgstr": ["password must be a minimum of 6 characters"]
+        "msgstr": [
+          "password must be a minimum of 6 characters"
+        ]
+      },
+      "CONFIRM_PWD_LBL": {
+        "msgid": "CONFIRM_PWD_LBL",
+        "msgstr": [
+          "Confirm password"
+        ]
+      },
+      "CONFIRM_PWD_PHOLD": {
+        "msgid": "CONFIRM_PWD_PHOLD",
+        "msgstr": [
+          "confirm password"
+        ]
       },
       "COUNTRY_LBL": {
         "msgid": "COUNTRY_LBL",
-        "msgstr": ["Country"]
+        "msgstr": [
+          "Country"
+        ]
       },
       "CITY_LBL": {
         "msgid": "CITY_LBL",
-        "msgstr": ["City"]
+        "msgstr": [
+          "City"
+        ]
       },
       "CITY_PHOLD": {
         "msgid": "CITY_PHOLD",
-        "msgstr": ["enter city"]
+        "msgstr": [
+          "enter city"
+        ]
       },
       "STREET_LBL": {
         "msgid": "STREET_LBL",
-        "msgstr": ["Street"]
+        "msgstr": [
+          "Street"
+        ]
       },
       "STREET_PHOLD": {
         "msgid": "STREET_PHOLD",
-        "msgstr": ["enter street"]
+        "msgstr": [
+          "enter street"
+        ]
       },
       "ZIP_CODE_LBL": {
         "msgid": "ZIP_CODE_LBL",
-        "msgstr": ["Postal code"]
+        "msgstr": [
+          "Postal code"
+        ]
       },
       "TAX_NUMBER_LBL": {
         "msgid": "TAX_NUMBER_LBL",
-        "msgstr": ["Tax number"]
+        "msgstr": [
+          "Tax number"
+        ]
       },
       "TAX_NUMBER_PHOLD": {
         "msgid": "TAX_NUMBER_PHOLD",
-        "msgstr": ["enter your tax identification number (optional)"]
+        "msgstr": [
+          "enter your tax identification number (optional)"
+        ]
       },
       "TAX_NUMBER_PTRN_DESC": {
         "msgid": "TAX_NUMBER_PTRN_DESC",
-        "msgstr": ["only numbers and letters"]
+        "msgstr": [
+          "only numbers and letters"
+        ]
       },
       "REGISTER_ADD_INFO_TXT": {
         "msgid": "REGISTER_ADD_INFO_TXT",
@@ -219,33 +411,119 @@
           "By signing up, you accept the {terms_and_conditions} and the {privacy_policy} of this WiFi service."
         ]
       },
+      "REGISTER_BTN_TXT": {
+        "msgid": "REGISTER_BTN_TXT",
+        "msgstr": [
+          "Sign up"
+        ]
+      },
       "FORGOT_PASSWORD": {
         "msgid": "FORGOT_PASSWORD",
-        "msgstr": ["Forgot your password?"]
+        "msgstr": [
+          "Forgot your password?"
+        ]
       },
       "LINKS_LOGIN_TXT": {
         "msgid": "LINKS_LOGIN_TXT",
-        "msgstr": ["Already have an account? Log in"]
+        "msgstr": [
+          "Already have an account? Log in"
+        ]
       },
       "REGISTRATION_TITL": {
         "msgid": "REGISTRATION_TITL",
-        "msgstr": ["Sign up"]
+        "msgstr": [
+          "Sign up"
+        ]
+      },
+      "PWD_CNF_ERR": {
+        "msgid": "PWD_CNF_ERR",
+        "msgstr": [
+          "The two password fields didn't match."
+        ]
+      },
+      "REGISTER_SUCCESS": {
+        "msgid": "REGISTER_SUCCESS",
+        "msgstr": [
+          "Registration success"
+        ]
+      },
+      "404_PG_TITL": {
+        "msgid": "404_PG_TITL",
+        "msgstr": [
+          "404 Not found"
+        ]
+      },
+      "REGISTER_ERR": {
+        "msgid": "REGISTER_ERR",
+        "msgstr": [
+          "Registration error."
+        ]
+      },
+      "NO_ORGS": {
+        "msgid": "NO_ORGS",
+        "msgstr": [
+          "A user with similar credentials already exists."
+        ]
+      },
+      "CONFLICT_ORGS": {
+        "msgid": "CONFLICT_ORGS",
+        "msgstr": [
+          "A user with credentials like the one being entered already exists in other organizations:"
+        ]
+      },
+      "CONFLICT_SIGNIN": {
+        "msgid": "CONFLICT_SIGNIN",
+        "msgstr": [
+          "Do you own the account mentioned above and want to sign in and associate your existing account to this WiFi service?"
+        ]
       },
       "PAY_SUCCESS": {
         "msgid": "PAY_SUCCESS",
-        "msgstr": ["Payment received successfully."]
+        "msgstr": [
+          "Payment received successfully."
+        ]
+      },
+      "PAY_REQ": {
+        "msgid": "PAY_REQ",
+        "msgstr": [
+          "Payment required to proceed"
+        ]
+      },
+      "PAY_WARN${ timeout }${ maxAttempts }": {
+        "msgid": "PAY_WARN${ timeout }${ maxAttempts }",
+        "msgstr": [
+          "<p>By clicking on the button below you will be redirected to our payment gateway service where you can safely use your credit/debit card. From there you will be redirected to the website of your bank to confirm the transaction.</p><p>You will have ${ timeout } minutes to complete the process.<br /><strong>For this reason we recommend preparing your debit/credit card before initiating the payment process.</strong></p><p>If for any reason the process is not completed within the available time, the internet connection which allows you to reach the website of your bank will be closed, if this happens you can just log in again with the credentials you just registered and repeat the process up a maximum of ${ maxAttempts } times.</p>"
+        ]
+      },
+      "PAY_PROC_BTN": {
+        "msgid": "PAY_PROC_BTN",
+        "msgstr": [
+          "Proceed with the payment"
+        ]
+      },
+      "PAY_GIVE_UP_BTN": {
+        "msgid": "PAY_GIVE_UP_BTN",
+        "msgstr": [
+          "Cancel operation and log out"
+        ]
       },
       "PAY_FAIL": {
         "msgid": "PAY_FAIL",
-        "msgstr": ["Payment Failed"]
+        "msgstr": [
+          "Payment Failed"
+        ]
       },
       "PAY_SUB_H": {
         "msgid": "PAY_SUB_H",
-        "msgstr": ["Something went wrong with the payment."]
+        "msgstr": [
+          "Something went wrong with the payment."
+        ]
       },
       "PAY_TRY_AGAIN_BTN": {
         "msgid": "PAY_TRY_AGAIN_BTN",
-        "msgstr": ["Try again"]
+        "msgstr": [
+          "Try again"
+        ]
       },
       "PAY_GIVE_UP_TXT": {
         "msgid": "PAY_GIVE_UP_TXT",
@@ -253,27 +531,47 @@
           "If you cannot complete the transaction you can either try to get in touch with your bank or cancel the operation."
         ]
       },
-      "PAY_GIVE_UP_BTN": {
-        "msgid": "PAY_GIVE_UP_BTN",
-        "msgstr": ["Cancel operation and log out"]
-      },
       "PWD_RESET_TITL": {
         "msgid": "PWD_RESET_TITL",
-        "msgstr": ["Reset Password"]
+        "msgstr": [
+          "Reset Password"
+        ]
       },
       "LOGIN_PG_LNK": {
         "msgid": "LOGIN_PG_LNK",
-        "msgstr": ["Go back to sign in"]
+        "msgstr": [
+          "Go back to sign in"
+        ]
       },
       "PWD_RESET_ADD_TXT": {
         "msgid": "PWD_RESET_ADD_TXT",
         "msgstr": [
-          "Have you forgot your password? Enter your email address, phone number or username below and we'll  send you the instructions to reset it."
+          "Have you forgot your password? Enter your email address, phone number or username below and we'll send you the instructions to reset it."
+        ]
+      },
+      "USERNAME_LOG_LBL": {
+        "msgid": "USERNAME_LOG_LBL",
+        "msgstr": [
+          "Email, phone number or username"
+        ]
+      },
+      "USERNAME_LOG_PHOLD": {
+        "msgid": "USERNAME_LOG_PHOLD",
+        "msgstr": [
+          "enter email, phone number or username"
+        ]
+      },
+      "USERNAME_LOG_TITL": {
+        "msgid": "USERNAME_LOG_TITL",
+        "msgstr": [
+          "enter valid email address, an username or a phone number"
         ]
       },
       "PWD_RESET_BTN": {
         "msgid": "PWD_RESET_BTN",
-        "msgstr": ["Reset My Password"]
+        "msgstr": [
+          "Reset password"
+        ]
       },
       "PWD_RESET_CNTC_TXT": {
         "msgid": "PWD_RESET_CNTC_TXT",
@@ -283,55 +581,105 @@
       },
       "PWD_CONFIRM_TITL": {
         "msgid": "PWD_CONFIRM_TITL",
-        "msgstr": ["Reset Password"]
+        "msgstr": [
+          "Reset Password"
+        ]
       },
       "PWD_CONFIRM_H": {
         "msgid": "PWD_CONFIRM_H",
-        "msgstr": ["Reset your password"]
+        "msgstr": [
+          "Reset your password"
+        ]
       },
       "PWD_CONFIRM_ADD_TXT": {
         "msgid": "PWD_CONFIRM_ADD_TXT",
-        "msgstr": ["Please enter your new password below."]
-      },
-      "CONFIRM_PWD_LBL": {
-        "msgid": "CONFIRM_PWD_LBL",
-        "msgstr": ["Confirm password"]
-      },
-      "CONFIRM_PWD_PHOLD": {
-        "msgid": "CONFIRM_PWD_PHOLD",
-        "msgstr": ["confirm password"]
+        "msgstr": [
+          "Please enter your new password below."
+        ]
       },
       "PWD_CONFIRM": {
         "msgid": "PWD_CONFIRM",
-        "msgstr": ["Change password"]
+        "msgstr": [
+          "Change password"
+        ]
       },
       "PWD_CHANGE_TITL": {
         "msgid": "PWD_CHANGE_TITL",
-        "msgstr": ["Change your password"]
+        "msgstr": [
+          "Change your password"
+        ]
+      },
+      "PWD_CURR_ERR": {
+        "msgid": "PWD_CURR_ERR",
+        "msgstr": [
+          "The new password cannot be the same as the current password."
+        ]
+      },
+      "PWD_CHNG_ERR": {
+        "msgid": "PWD_CHNG_ERR",
+        "msgstr": [
+          "An error occurred, the password has not been changed."
+        ]
       },
       "PWD_CHANGE_HELP_TXT": {
         "msgid": "PWD_CHANGE_HELP_TXT",
-        "msgstr": ["Use the form below to change your password."]
+        "msgstr": [
+          "Use the form below to change your password."
+        ]
+      },
+      "CURR_PWD_LBL": {
+        "msgid": "CURR_PWD_LBL",
+        "msgstr": [
+          "Current password"
+        ]
+      },
+      "CURR_PWD_PHOLD": {
+        "msgid": "CURR_PWD_PHOLD",
+        "msgstr": [
+          "Your current password"
+        ]
       },
       "PWD1_LBL": {
         "msgid": "PWD1_LBL",
-        "msgstr": ["New Password"]
+        "msgstr": [
+          "New Password"
+        ]
+      },
+      "PWD1_PHOLD": {
+        "msgid": "PWD1_PHOLD",
+        "msgstr": [
+          "Your new password"
+        ]
       },
       "PASSWORD_CHANGE": {
         "msgid": "PASSWORD_CHANGE",
-        "msgstr": ["Change Password"]
+        "msgstr": [
+          "Change Password"
+        ]
+      },
+      "CANCEL": {
+        "msgid": "CANCEL",
+        "msgstr": [
+          "Cancel"
+        ]
       },
       "DEFAULT_TITL${ orgName }": {
         "msgid": "DEFAULT_TITL${ orgName }",
-        "msgstr": ["Login to ${ orgName }"]
+        "msgstr": [
+          "Login to ${ orgName }"
+        ]
       },
       "PHONE_VERIF_TITL": {
         "msgid": "PHONE_VERIF_TITL",
-        "msgstr": ["Verify mobile number"]
+        "msgstr": [
+          "Verify mobile number"
+        ]
       },
       "TOKEN_SENT": {
         "msgid": "TOKEN_SENT",
-        "msgstr": ["SMS verification code sent successfully."]
+        "msgstr": [
+          "SMS verification code sent successfully."
+        ]
       },
       "PHONE_VERIFY (${ phone_number })": {
         "msgid": "PHONE_VERIFY (${ phone_number })",
@@ -341,11 +689,21 @@
       },
       "MOBILE_CODE_PHOLD": {
         "msgid": "MOBILE_CODE_PHOLD",
-        "msgstr": ["enter SMS verification code"]
+        "msgstr": [
+          "enter SMS verification code"
+        ]
       },
       "MOBILE_CODE_TITL": {
         "msgid": "MOBILE_CODE_TITL",
-        "msgstr": ["this field must be a 6 digit numeric code"]
+        "msgstr": [
+          "this field must be a 6 digit numeric code"
+        ]
+      },
+      "MOBILE_PHONE_VERIFY": {
+        "msgid": "MOBILE_PHONE_VERIFY",
+        "msgstr": [
+          "Submit"
+        ]
       },
       "RESEND_TOKEN_LBL": {
         "msgid": "RESEND_TOKEN_LBL",
@@ -353,135 +711,65 @@
           "If you did not receive the verification SMS code, you can try sending it again by clicking below."
         ]
       },
-      "RESEND_TOKEN_WAIT_LBL": {
-        "msgid": "RESEND_TOKEN_WAIT_LBL${ cooldown }",
-        "msgstr": ["A new SMS can be requested in ${ cooldown } seconds."]
+      "RESEND_TOKEN_WAIT_LBL${ seconds }": {
+        "msgid": "RESEND_TOKEN_WAIT_LBL${ seconds }",
+        "msgstr": [
+          "A new SMS can be requested in ${ cooldown } seconds."
+        ]
       },
       "RESEND_TOKEN": {
         "msgid": "RESEND_TOKEN",
-        "msgstr": ["Send a new verification code"]
+        "msgstr": [
+          "Send a new verification code"
+        ]
       },
       "PHONE_CHANGE_LBL": {
         "msgid": "PHONE_CHANGE_LBL",
-        "msgstr": ["Wrong phone number?"]
+        "msgstr": [
+          "Wrong phone number?"
+        ]
+      },
+      "PHONE_CHANGE_BTN": {
+        "msgid": "PHONE_CHANGE_BTN",
+        "msgstr": [
+          "Change your phone number"
+        ]
       },
       "LOGOUT_LBL": {
         "msgid": "LOGOUT_LBL",
-        "msgstr": ["If you need to cancel the process you can log out below."]
+        "msgstr": [
+          "If you need to cancel the process you can log out below."
+        ]
       },
       "PHONE_CHANGE_TITL": {
         "msgid": "PHONE_CHANGE_TITL",
-        "msgstr": ["Change mobile number"]
+        "msgstr": [
+          "Change mobile number"
+        ]
+      },
+      "LOGIN_SUCCESS": {
+        "msgid": "LOGIN_SUCCESS",
+        "msgstr": [
+          "Login successful"
+        ]
       },
       "LOGOUT_CONTENT": {
         "msgid": "LOGOUT_CONTENT",
-        "msgstr": ["Logout successful"]
+        "msgstr": [
+          "Logout successful"
+        ]
       },
       "LOGIN_AGAIN": {
         "msgid": "LOGIN_AGAIN",
-        "msgstr": ["Login again"]
-      },
-      "USERNAME_LOG_TITL": {
-        "msgid": "USERNAME_LOG_TITL",
-        "msgstr": ["enter valid email address, an username or a phone number"]
-      },
-      "REMEMBER_ME": {
-        "msgid": "REMEMBER_ME",
-        "msgstr": ["remember me on this device"]
-      },
-      "LOGIN_ADD_INFO_TXT": {
-        "msgid": "LOGIN_ADD_INFO_TXT",
         "msgstr": [
-          "By logging in, you accept the {terms_and_conditions} and the {privacy_policy} of this WiFi service. "
+          "Login again"
         ]
       },
       "LOGIN": {
         "msgid": "LOGIN",
-        "msgstr": ["Log in"]
-      },
-      "REGISTER_BTN_LBL": {
-        "msgid": "REGISTER_BTN_LBL",
-        "msgstr": ["Not registered yet?"]
-      },
-      "REGISTER_BTN_TXT": {
-        "msgid": "REGISTER_BTN_TXT",
-        "msgstr": ["Sign up"]
-      },
-      "EMAIL": {
-        "msgid": "EMAIL",
-        "msgstr": ["Email"]
-      },
-      "HELPDESK": {
-        "msgid": "HELPDESK",
-        "msgstr": ["Helpdesk"]
-      },
-      "404_PG_TITL": {
-        "msgid": "404_PG_TITL",
-        "msgstr": ["404 Not found"]
-      },
-      "404_H": {
-        "msgid": "404_H",
-        "msgstr": ["404"]
-      },
-      "404_SUBH": {
-        "msgid": "404_SUBH",
-        "msgstr": ["Not Found"]
-      },
-      "404_MESSAGE": {
-        "msgid": "404_MESSAGE",
-        "msgstr": ["Sorry, we couldn't find the page you were looking for."]
-      },
-      "PHONE_CHANGE_BTN": {
-        "msgid": "PHONE_CHANGE_BTN",
-        "msgstr": ["Change your phone number"]
-      },
-      "CANCEL": {
-        "msgid": "CANCEL",
-        "msgstr": ["Cancel"]
-      },
-      "OPTIONAL": {
-        "msgid": "OPTIONAL",
-        "msgstr": ["optional"]
-      },
-      "MOBILE_PHONE_VERIFY": {
-        "msgid": "MOBILE_PHONE_VERIFY",
-        "msgstr": ["Submit"]
-      },
-      "HOME_PG_LINK_TXT": {
-        "msgid": "HOME_PG_LINK_TXT",
-        "msgstr": ["Go back to homepage"]
-      },
-      "ERR_OCCUR": {
-        "msgid": "ERR_OCCUR",
-        "msgstr": ["Error occurred!"]
-      },
-      "LOGIN_ERR": {
-        "msgid": "LOGIN_ERR",
-        "msgstr": ["Login error occurred."]
-      },
-      "LOGIN_SUCCESS": {
-        "msgid": "LOGIN_SUCCESS",
-        "msgstr": ["Login successful"]
-      },
-      "LOGOUT_SUCCESS": {
-        "msgid": "LOGOUT_SUCCESS",
-        "msgstr": ["Logout successful"]
-      },
-      "PWD_CHNG_ERR": {
-        "msgid": "PWD_CHNG_ERR",
-        "msgstr": ["An error occurred, the password has not been changed."]
-      },
-      "PWD_CNF_ERR": {
-        "msgid": "PWD_CNF_ERR",
-        "msgstr": ["The two password fields didn't match."]
-      },
-      "REGISTER_ERR": {
-        "msgid": "REGISTER_ERR",
-        "msgstr": ["Registration error."]
-      },
-      "REGISTER_SUCCESS": {
-        "msgid": "REGISTER_SUCCESS",
-        "msgstr": ["Registration success"]
+        "msgstr": [
+          "Log in"
+        ]
       },
       "USER_INACTIVE": {
         "msgid": "USER_INACTIVE",
@@ -489,73 +777,59 @@
           "Your account has been deactivated. Please contact customer support for more information."
         ]
       },
-      "USERNAME_REG_LBL": {
-        "msgid": "USERNAME_REG_LBL",
-        "msgstr": ["Username"]
-      },
-      "USERNAME_REG_PHOLD": {
-        "msgid": "USERNAME_REG_PHOLD",
-        "msgstr": ["Username"]
-      },
-      "CP_LOGIN": {
-        "msgid": "CP_LOGIN",
+      "LOGIN_ERR": {
+        "msgid": "LOGIN_ERR",
         "msgstr": [
-          "We are initializing your session in the WiFi service, it may take a few seconds, please wait ..."
+          "Login error occurred."
         ]
       },
-      "PAY_REQ": {
-        "msgid": "PAY_REQ",
-        "msgstr": ["Payment required to proceed"]
-      },
-      "PAY_PROC_BTN": {
-        "msgid": "PAY_PROC_BTN",
-        "msgstr": ["Proceed with the payment"]
-      },
-      "PAY_WARN${ timeout }${ maxAttempts }": {
-        "msgid": "PAY_WARN${ timeout }${ maxAttempts }",
+      "REMEMBER_ME": {
+        "msgid": "REMEMBER_ME",
         "msgstr": [
-          "<p>By clicking on the button below you will be redirected to our payment gateway service where you can safely use your credit/debit card. From there you will be redirected to the website of your bank to confirm the transaction.</p><p>You will have ${ timeout } minutes to complete the process.<br /><strong>For this reason we recommend preparing your debit/credit card before initiating the payment process.</strong></p><p>If for any reason the process is not completed within the available time, the internet connection which allows you to reach the website of your bank will be closed, if this happens you can just log in again with the credentials you just registered and repeat the process up a maximum of ${ maxAttempts } times.</p>"
+          "remember me on this device"
         ]
       },
-      "PLEASE_WAIT": {
-        "msgid": "PLEASE_WAIT",
-        "msgstr": ["Please wait..."]
-      },
-      "PLEASE_LOGIN": {
-        "msgid": "PLEASE_LOGIN",
-        "msgstr": [""]
-      },
-      "CONFLICT_ORGS": {
-        "msgid": "CONFLICT_ORGS",
+      "LOGIN_ADD_INFO_TXT": {
+        "msgid": "LOGIN_ADD_INFO_TXT",
         "msgstr": [
-          "A user with credentials like the one being entered already exists in other organizations:"
+          "By logging in, you accept the {terms_and_conditions} and the {privacy_policy} of this WiFi service. "
         ]
       },
-      "NO_ORGS": {
-        "msgid": "NO_ORGS",
-        "msgstr": ["A user with these credentials already exists."]
-      },
-      "CONFLICT_SIGNIN": {
-        "msgid": "CONFLICT_SIGNIN",
+      "REGISTER_BTN_LBL": {
+        "msgid": "REGISTER_BTN_LBL",
         "msgstr": [
-          "Do you own the account mentioned above and want to sign in with this organization?"
+          "Not registered yet?"
         ]
       },
-      "PWD_CURR_ERR": {
-        "msgid": "PWD_CURR_ERR",
-        "msgstr": ["The password is the same as the current password."]
+      "HELPDESK": {
+        "msgid": "HELPDESK",
+        "msgstr": [
+          "Helpdesk"
+        ]
       },
-      "CURR_PWD_LBL": {
-        "msgid": "CURR_PWD_LBL",
-        "msgstr": ["Current password"]
+      "404_H": {
+        "msgid": "404_H",
+        "msgstr": [
+          "404"
+        ]
       },
-      "CURR_PWD_PHOLD": {
-        "msgid": "CURR_PWD_PHOLD",
-        "msgstr": ["Your current password"]
+      "404_SUBH": {
+        "msgid": "404_SUBH",
+        "msgstr": [
+          "Not Found"
+        ]
       },
-      "PWD1_PHOLD": {
-        "msgid": "PWD1_PHOLD",
-        "msgstr": ["Your new password"]
+      "404_MESSAGE": {
+        "msgid": "404_MESSAGE",
+        "msgstr": [
+          "Sorry, we couldn't find the page you were looking for."
+        ]
+      },
+      "HOME_PG_LINK_TXT": {
+        "msgid": "HOME_PG_LINK_TXT",
+        "msgstr": [
+          "Go back to homepage"
+        ]
       }
     }
   }

--- a/config/build-test-translation.js
+++ b/config/build-test-translation.js
@@ -1,0 +1,167 @@
+/*
+ * It converts PO files (i18n/*.po) to test-translation.json format for testing purposes.
+ * This script automatically generates client/test-translation.json from the English .po file
+ * to ensure test translations are always up-to-date with the source translations.
+ */
+/* eslint-disable no-restricted-syntax */
+/* eslint-disable no-console */
+const fs = require("fs");
+const path = require("path");
+
+const rootDir = process.cwd();
+const i18nDir = path.join(rootDir, "i18n");
+const testTranslationFile = path.join(rootDir, "client", "test-translation.json");
+
+
+const parsePoFile = (filePath) => {
+  console.log("Reading file:", filePath);
+  const content = fs.readFileSync(filePath, "utf8");
+  const lines = content.split("\n");
+
+  const translations = { "": {} };
+  let currentMsgid = null;
+  let currentMsgstr = null;
+  let state = null; // "msgid", "msgstr", or null
+
+  const saveTranslation = () => {
+    if (currentMsgid !== null && currentMsgstr !== null) {
+      translations[""][currentMsgid] = currentMsgstr;
+    }
+    currentMsgid = null;
+    currentMsgstr = null;
+    state = null;
+  };
+
+  for (let line of lines) {
+    line = line.trim();
+
+    if (line === "" || line.startsWith("#")) {
+      // End of a block, so save if we have data
+      if (currentMsgid !== null && currentMsgstr !== null) {
+        saveTranslation();
+      }
+      continue;
+    }
+
+    if (line.startsWith("msgid")) {
+      if (currentMsgid !== null && currentMsgstr !== null) {
+        saveTranslation();
+      }
+      currentMsgid = line.substring(5).trim().replace(/^"|"$/g, "");
+      state = "msgid";
+    } else if (line.startsWith("msgstr")) {
+      currentMsgstr = line.substring(6).trim().replace(/^"|"$/g, "");
+      state = "msgstr";
+    } else if (line.startsWith('"')) {
+      const text = line.replace(/^"|"$/g, "");
+      if (state === "msgid" && currentMsgid !== null) {
+        currentMsgid += text;
+      } else if (state === "msgstr" && currentMsgstr !== null) {
+        currentMsgstr += text;
+      }
+    }
+  }
+
+  // Final entry at EOF
+  if (currentMsgid !== null && currentMsgstr !== null) {
+    saveTranslation();
+  }
+
+  return translations;
+};
+
+
+const convertToTestFormat = (poTranslations) => {
+  const headers = {
+    "content-type": "text/plain; charset=utf-8",
+    "plural-forms": "nplurals = 2; plural = (n != 1);",
+    "language": "en",
+    "mime-version": "1.0",
+    "content-transfer-encoding": "8bit"
+  };
+
+  const testTranslations = { "": {} };
+
+  // Handle translations in the default context
+  const contextTranslations = poTranslations[""];
+  Object.keys(contextTranslations).forEach((msgid) => {
+    const msgstr = contextTranslations[msgid];
+
+    if (msgid === "") {
+      // Header block
+      testTranslations[""][""] = {
+        msgid: "",
+        msgstr: [msgstr]
+      };
+    } else {
+      // Regular translations
+      testTranslations[""][msgid] = {
+        msgid: msgid,
+        msgstr: [msgstr]
+      };
+    }
+  });
+
+  return {
+    charset: "utf-8",
+    headers: headers,
+    translations: testTranslations
+  };
+};
+
+const buildTestTranslation = () => {
+  console.log("Building test-translation.json from .po files...");
+  
+  // Check if i18n directory exists
+  if (!fs.existsSync(i18nDir)) {
+    console.error("i18n directory not found!");
+    process.exit(1);
+  }
+
+  // Get all .po files
+  const allFiles = fs.readdirSync(i18nDir);
+  const poFiles = allFiles.filter(
+    (file) => file.indexOf("custom") === -1 && path.extname(file) === ".po"
+  );
+
+  if (poFiles.length === 0) {
+    console.error("No .po files found in i18n directory!");
+    process.exit(1);
+  }
+
+  // Use English .po file as the base for test translations
+  const englishPoFile = poFiles.find(file => file === "en.po");
+  if (!englishPoFile) {
+    console.error("English .po file (en.po) not found!");
+    process.exit(1);
+  }
+
+  console.log(`Converting ${englishPoFile} to test format...`);
+  
+  // Parse PO file directly
+  const poFilePath = path.join(i18nDir, englishPoFile);
+  const poTranslations = parsePoFile(poFilePath);
+  console.log(poTranslations);
+  
+  // Convert to test format
+  const testTranslation = convertToTestFormat(poTranslations);
+  
+  // Write the test translation file
+  try {
+    fs.writeFileSync(
+      testTranslationFile,
+      JSON.stringify(testTranslation, null, 2)
+    );
+    console.log(`Successfully generated ${testTranslationFile}`);
+  } catch (err) {
+    console.error("Error writing test-translation.json:", err);
+    process.exit(1);
+  }
+};
+
+// Run the script if called directly
+if (require.main === module) {
+  buildTestTranslation();
+}
+
+module.exports = { buildTestTranslation }; 

--- a/config/verify-test-translation.js
+++ b/config/verify-test-translation.js
@@ -1,0 +1,69 @@
+/*
+ * Verification script to check if test-translation.json was properly generated
+ */
+const fs = require("fs");
+const path = require("path");
+
+const testTranslationFile = path.join(process.cwd(), "client", "test-translation.json");
+
+const verifyTestTranslation = () => {
+  console.log("Verifying test-translation.json...");
+  
+  if (!fs.existsSync(testTranslationFile)) {
+    console.error("❌ test-translation.json not found!");
+    return false;
+  }
+
+  try {
+    const content = JSON.parse(fs.readFileSync(testTranslationFile, "utf8"));
+    
+    // Check basic structure
+    if (!content.translations || !content.headers) {
+      console.error("❌ Invalid structure: missing translations or headers");
+      return false;
+    }
+
+    // Check if we have actual translations (excluding the empty msgid)
+    const translations = content.translations[""] || {};
+    const translationKeys = Object.keys(translations).filter(key => key !== "");
+    const translationCount = translationKeys.length;
+    console.log(`✅ Found ${translationCount} translations`);
+    
+    // Check a few specific translations
+    const sampleTranslations = [
+      "PWD_REVEAL",
+      "PWD_HIDE", 
+      "LOGIN",
+      "USERNAME"
+    ];
+    
+    let foundCount = 0;
+    sampleTranslations.forEach(key => {
+      if (translations[key]) {
+        console.log(`✅ Found translation for: ${key} -> "${translations[key].msgstr[0]}"`);
+        foundCount++;
+      } else {
+        console.log(`❌ Missing translation for: ${key}`);
+      }
+    });
+    
+    if (foundCount === sampleTranslations.length) {
+      console.log("✅ All sample translations found!");
+      return true;
+    } else {
+      console.log(`❌ Only ${foundCount}/${sampleTranslations.length} sample translations found`);
+      return false;
+    }
+    
+  } catch (err) {
+    console.error("❌ Error reading test-translation.json:", err.message);
+    return false;
+  }
+};
+
+if (require.main === module) {
+  const success = verifyTestTranslation();
+  process.exit(success ? 0 : 1);
+}
+
+module.exports = { verifyTestTranslation }; 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,8 @@
     "webpack-dev-server": "^5.2.1"
   },
   "scripts": {
+    "build-test-translation": "node config/build-test-translation.js",
+    "verify-test-translation": "node config/verify-test-translation.js",
     "build": "export NODE_OPTIONS=--openssl-legacy-provider && npm run setup && webpack --mode production --progress --config config/webpack.config.js",
     "build-dev": "export NODE_OPTIONS=--openssl-legacy-provider && npm run setup && webpack --mode development --progress --config config/webpack.config.js",
     "client": "export NODE_OPTIONS=--openssl-legacy-provider && npm run setup && webpack serve --host 0.0.0.0 --mode development --config config/webpack.config.js",
@@ -128,7 +130,7 @@
     "lint:fix": "eslint '**/*.{js,jsx}' --fix",
     "format": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",
     "format:check": "prettier -c \"**/*.+(js|jsx|json|css|md)\"",
-    "test": "jest client",
+    "test": "npm run build-test-translation && npm run verify-test-translation && jest client",
     "browser-test": "./browser-test/wait_for_url.sh http://0.0.0.0:8080 http://localhost:8000/admin && jest browser-test --runInBand",
     "test-inspect": "node inspect ./node_modules/.bin/jest --runInBand",
     "stats": "STATS=true webpack-cli --profile --json --mode production --config config/webpack.config.js > compilation-stats.json && webpack-bundle-analyzer dist/stats.json",


### PR DESCRIPTION
## Checklist
- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

Closes #195

## Description of Changes

This PR introduces automation for generating the `client/test-translation.json` file from the existing `.po` translation files, specifically `en.po`.

### Summary of changes:
- Added `build-test-translation.js` to generate `test-translation.json` from `en.po`
- Added `verify-test-translation.js` to ensure the file is kept in sync
- Updated `package.json` to include scripts for generation and verification
- Modified `test` script to automatically build translation before running tests
- Removed the need for manual updates to test-translation.json

This reduces maintenance overhead and ensures translated test snapshots are always up-to-date.

## Screenshot

_No UI changes._

