### PR TITLE
[fix] Make plans modal in status scrollable

### DIFF
--- a/client/components/registration/__snapshots__/registration.test.js.snap
+++ b/client/components/registration/__snapshots__/registration.test.js.snap
@@ -26,7 +26,9 @@ exports[`<Registration /> interactions should show modal if user is already regi
     >
       ✖
     </button>
-    <div>
+    <div
+      className={null}
+    >
       <div
         className="message"
       >
@@ -82,7 +84,9 @@ exports[`<Registration /> interactions should show modal if user is registered b
     >
       ✖
     </button>
-    <div>
+    <div
+      className={null}
+    >
       <div
         className="message"
       >

--- a/client/components/status/__snapshots__/status.test.js.snap
+++ b/client/components/status/__snapshots__/status.test.js.snap
@@ -13,6 +13,7 @@ exports[`<Status /> interactions should hide check if check.value is zero 1`] = 
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -219,6 +220,7 @@ exports[`<Status /> interactions should show user's radius usage 1`] = `
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -447,6 +449,7 @@ exports[`<Status /> interactions subscriptions: should hide checks and show upgr
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -635,6 +638,7 @@ exports[`<Status /> interactions subscriptions: should show upgrade option when 
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -867,6 +871,7 @@ exports[`<Status /> interactions subscriptions: should show upgrade option when 
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -952,6 +957,7 @@ exports[`<Status /> interactions subscriptions: should show upgrade option when 
       handleResponse={[Function]}
       id="upgrade-plan-modal"
       isConfirmationDialog={false}
+      isScrollable={true}
       toggleModal={[Function]}
     />
     <div
@@ -1180,6 +1186,7 @@ exports[`<Status /> interactions subscriptions: should show upgrade option when 
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -1412,6 +1419,7 @@ exports[`<Status /> interactions subscriptions: should show upgrade option when 
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -1497,6 +1505,7 @@ exports[`<Status /> interactions subscriptions: should show upgrade option when 
       handleResponse={[Function]}
       id="upgrade-plan-modal"
       isConfirmationDialog={false}
+      isScrollable={true}
       toggleModal={[Function]}
     />
     <div
@@ -1725,6 +1734,7 @@ exports[`<Status /> rendering should render correctly 1`] = `
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div
@@ -1891,6 +1901,7 @@ exports[`<Status /> rendering with placeholder translation tags should render tr
     }
     handleResponse={[Function]}
     isConfirmationDialog={true}
+    isScrollable={false}
     toggleModal={[Function]}
   />
   <div

--- a/client/components/status/index.css
+++ b/client/components/status/index.css
@@ -115,18 +115,15 @@ progress + p.progress {
   margin-top: 15px;
   line-height: 1.5em;
 }
-#status .plans {
-  margin: 0 30px;
-}
 #status .plans .intro {
   margin-top: 0px;
   margin-bottom: 15px;
 }
 #status .plans .plan {
-  padding: 20px;
+  padding: 10px;
   margin-bottom: 20px;
   text-align: left;
-  line-height: 1.8em;
+  line-height: 1.6em;
   border: 1px solid #b4b4b4 !important;
 }
 #status .plans .plan:last-child {

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -1145,6 +1145,7 @@ export default class Status extends React.Component {
               toggleModal={this.toggleUpgradePlanModal}
               handleResponse={() => {}}
               isConfirmationDialog={false}
+              isScrollable
               content={
                 (upgradePlans.length &&
                   getPlanSelection(

--- a/client/utils/modal.js
+++ b/client/utils/modal.js
@@ -5,8 +5,15 @@ import "./modal.css";
 
 class InfoModal extends Component {
   render() {
-    const {active, toggleModal, handleResponse, content, isConfirmationDialog} =
-      this.props;
+    const {
+      active,
+      toggleModal,
+      handleResponse,
+      content,
+      isConfirmationDialog,
+      isScrollable,
+    } = this.props;
+
     return (
       <div className={active ? "modal is-visible" : "modal"}>
         <div className="modal-container bg">
@@ -17,7 +24,7 @@ class InfoModal extends Component {
           >
             &#10006;
           </button>
-          <div>{content}</div>
+          <div className={isScrollable ? "message" : null}>{content}</div>
           {isConfirmationDialog && (
             <p className="modal-buttons">
               <button
@@ -50,7 +57,9 @@ InfoModal.propTypes = {
   handleResponse: propTypes.func.isRequired,
   content: propTypes.object.isRequired,
   isConfirmationDialog: propTypes.bool,
+  isScrollable: propTypes.bool,
 };
 InfoModal.defaultProps = {
   isConfirmationDialog: true,
+  isScrollable: false,
 };


### PR DESCRIPTION
Allow making modal scrollable and enable this behavior in the plans modal, works as in the gif below.

 ![plans-scrollable](https://github.com/user-attachments/assets/b45a03f0-4b47-4fdf-8242-e52dcea4c463)
