### PR TITLE
[ci] Start redis before startin openwisp-radius

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,11 @@ jobs:
           key: ${{ runner.os }}-pip-${{ env.OW_RADIUS_VERSION }}
           restore-keys: ${{ runner.os }}-pip-
 
+      - name: Start InfluxDB and Redis container
+        run: |
+          cd openwisp-radius
+          docker compose up -d redis
+
       - name: Installing OpenWISP Radius
         run: |
           cd openwisp-radius


### PR DESCRIPTION
The dev env of OpenWISP RADIUS now requires redis: https://github.com/openwisp/openwisp-radius/commit/5f2da45f96441410d049bce12715d6d24de69879.