### PR TITLE
[tests] Use 127.0.0.1:8080 instead of 0.0.0.0:8080 in browser tests

### DIFF
--- a/browser-test/js-file-inject.test.js
+++ b/browser-test/js-file-inject.test.js
@@ -27,7 +27,7 @@ describe("Selenium tests to check JS file injection in organization page", () =>
         scriptSources.push(await script.getAttribute("src"));
       }),
     );
-    expect(scriptSources.includes(`http://0.0.0.0:8080/${jsFile}`)).toEqual(
+    expect(scriptSources.includes(`http://127.0.0.1:8080/${jsFile}`)).toEqual(
       true,
     );
     const data = initialData().mobileVerificationTestUser;
@@ -39,7 +39,7 @@ describe("Selenium tests to check JS file injection in organization page", () =>
         scriptSources.push(await script.getAttribute("src"));
       }),
     );
-    expect(scriptSources.includes(`http://0.0.0.0:8080/${jsFile}`)).toEqual(
+    expect(scriptSources.includes(`http://127.0.0.1:8080/${jsFile}`)).toEqual(
       true,
     );
   });

--- a/browser-test/utils.js
+++ b/browser-test/utils.js
@@ -71,22 +71,22 @@ export const getPhoneToken = () => {
 };
 
 export const urls = {
-  registration: `http://0.0.0.0:8080/${orgSlug}/registration`,
-  registrationTos: `http://0.0.0.0:8080/${orgSlug}/registration/terms-and-conditions`,
-  registrationPrivacy: `http://0.0.0.0:8080/${orgSlug}/registration/privacy-policy`,
-  login: `http://0.0.0.0:8080/${orgSlug}/login`,
-  loginTos: `http://0.0.0.0:8080/${orgSlug}/login/terms-and-conditions`,
-  loginPrivacy: `http://0.0.0.0:8080/${orgSlug}/login/privacy-policy`,
-  status: `http://0.0.0.0:8080/${orgSlug}/status`,
-  passwordChange: `http://0.0.0.0:8080/${orgSlug}/change-password`,
-  passwordReset: `http://0.0.0.0:8080/${orgSlug}/password/reset`,
+  registration: `http://127.0.0.1:8080/${orgSlug}/registration`,
+  registrationTos: `http://127.0.0.1:8080/${orgSlug}/registration/terms-and-conditions`,
+  registrationPrivacy: `http://127.0.0.1:8080/${orgSlug}/registration/privacy-policy`,
+  login: `http://127.0.0.1:8080/${orgSlug}/login`,
+  loginTos: `http://127.0.0.1:8080/${orgSlug}/login/terms-and-conditions`,
+  loginPrivacy: `http://127.0.0.1:8080/${orgSlug}/login/privacy-policy`,
+  status: `http://127.0.0.1:8080/${orgSlug}/status`,
+  passwordChange: `http://127.0.0.1:8080/${orgSlug}/change-password`,
+  passwordReset: `http://127.0.0.1:8080/${orgSlug}/password/reset`,
   passwordConfirm: (uid, token) =>
-    `http://0.0.0.0:8080/${orgSlug}/password/reset/confirm/${uid}/${token}`,
-  verificationLogin: (slug) => `http://0.0.0.0:8080/${slug}/login`,
+    `http://127.0.0.1:8080/${orgSlug}/password/reset/confirm/${uid}/${token}`,
+  verificationLogin: (slug) => `http://127.0.0.1:8080/${slug}/login`,
   mobileVerification: (slug) =>
-    `http://0.0.0.0:8080/${slug}/mobile-phone-verification`,
+    `http://127.0.0.1:8080/${slug}/mobile-phone-verification`,
   mobilePhoneChange: (slug) =>
-    `http://0.0.0.0:8080/${slug}/change-phone-number`,
+    `http://127.0.0.1:8080/${slug}/change-phone-number`,
 };
 
 export const successToastSelector = ".Toastify__toast--success div[role=alert]";

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "format": "prettier --write \"**/*.+(js|jsx|json|css|md)\"",
     "format:check": "prettier -c \"**/*.+(js|jsx|json|css|md)\"",
     "test": "jest --testPathIgnorePatterns=/browser-test/",
-    "browser-test": "./browser-test/wait_for_url.sh http://0.0.0.0:8080 http://localhost:8000/admin && jest browser-test --runInBand",
+    "browser-test": "./browser-test/wait_for_url.sh http://localhost:8080 http://localhost:8000/admin && jest browser-test --runInBand",
     "test-inspect": "node inspect ./node_modules/.bin/jest --runInBand",
     "stats": "STATS=true webpack-cli --profile --json --mode production --config config/webpack.config.js > compilation-stats.json && webpack-bundle-analyzer dist/stats.json",
     "translations-add": "ttag init",


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [ ] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.
