### PR TITLE
[client/utils] fix authenticate logic to avoid removing auth cookies

### DIFF
--- a/client/utils/authenticate.js
+++ b/client/utils/authenticate.js
@@ -4,8 +4,6 @@ const authenticate = (cookies, orgSlug) => {
   const token = cookies.get(`${orgSlug}_auth_token`);
   const sessionKey = sessionStorage.getItem(`${orgSlug}_auth_token`);
   if (sessionKey) {
-    cookies.remove(`${orgSlug}_auth_token`, {path: "/"});
-    cookies.remove(`${orgSlug}_username`, {path: "/"});
     return true;
   }
   if (token) return true;

--- a/client/utils/authenticate.test.js
+++ b/client/utils/authenticate.test.js
@@ -1,0 +1,40 @@
+import authenticate from "./authenticate";
+import {sessionStorage} from "./storage";
+
+describe("authenticate", () => {
+  let cookies;
+  beforeEach(() => {
+    cookies = {
+      get: jest.fn(),
+      remove: jest.fn(),
+    };
+    sessionStorage.getItem = jest.fn();
+  });
+
+  test("returns true when sessionStorage has the auth token and does not remove cookies", () => {
+    sessionStorage.getItem.mockReturnValue("some-session-key");
+    cookies.get.mockReturnValue(undefined);
+
+    const result = authenticate(cookies, "org");
+    expect(result).toBe(true);
+    expect(cookies.remove).not.toHaveBeenCalled();
+  });
+
+  test("returns true when cookie token is present", () => {
+    sessionStorage.getItem.mockReturnValue(undefined);
+    cookies.get.mockReturnValue("cookie-token");
+
+    const result = authenticate(cookies, "org");
+    expect(result).toBe(true);
+    expect(cookies.remove).not.toHaveBeenCalled();
+  });
+
+  test("returns false when no sessionKey and no cookie token", () => {
+    sessionStorage.getItem.mockReturnValue(undefined);
+    cookies.get.mockReturnValue(undefined);
+
+    const result = authenticate(cookies, "org");
+    expect(result).toBe(false);
+    expect(cookies.remove).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The authenicated() function removed authentication cookies while checking if a user was authenticated, causing unexpected logouts. This change ensures the authentication check does not mutate cookies or session storage while only verifying authentication state. Tests in `client/utils/authenticate.test.js` were updated to cover sessionStorage and cookie scenarios.

Fixes #958

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [ ] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #958.

Please [open a new issue](https://github.com/openwisp/openwisp-wifi-login-pages/issues/new/choose) if there isn't an existing issue yet.

## Description of Changes
- Fixes logic in `authenticate.js` so the authentication check does not remove cookies or `sessionStorage` preventing unexpected logouts.

- Added `authenicate.test.js` to cover sessionStorage aand cookie scenarios and assert no side-effects 


## Screenshot

N / A
