### PR TITLE
[fix] Fixed SMS cooldown translation texts

### DIFF
--- a/client/test-translation.json
+++ b/client/test-translation.json
@@ -354,8 +354,8 @@
         ]
       },
       "RESEND_TOKEN_WAIT_LBL": {
-        "msgid": "RESEND_TOKEN_WAIT_LBL${ cooldown }",
-        "msgstr": ["A new SMS can be requested in ${ cooldown } seconds."]
+        "msgid": "RESEND_TOKEN_WAIT_LBL${ seconds }",
+        "msgstr": ["A new SMS can be requested in ${ seconds } seconds."]
       },
       "RESEND_TOKEN": {
         "msgid": "RESEND_TOKEN",

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -598,7 +598,7 @@ msgstr ""
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:286
 #, fuzzy, javascript-format
 msgid "RESEND_TOKEN_WAIT_LBL${ seconds }"
-msgstr "Eine neue SMS kann in ${ cooldown } Sekunden angefordert werden."
+msgstr "Eine neue SMS kann in ${ seconds } Sekunden angefordert werden."
 
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:301
 msgid "RESEND_TOKEN"

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -591,7 +591,7 @@ msgstr ""
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:286
 #, fuzzy, javascript-format
 msgid "RESEND_TOKEN_WAIT_LBL${ seconds }"
-msgstr "A new SMS can be requested in ${ cooldown } seconds."
+msgstr "A new SMS can be requested in ${ seconds } seconds."
 
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:301
 msgid "RESEND_TOKEN"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -602,7 +602,7 @@ msgstr ""
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:286
 #, javascript-format
 msgid "RESEND_TOKEN_WAIT_LBL${ seconds }"
-msgstr "Se puede solicitar un nuevo SMS en ${ cooldown } segundos."
+msgstr "Se puede solicitar un nuevo SMS en ${ seconds } segundos."
 
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:301
 msgid "RESEND_TOKEN"

--- a/i18n/fur.po
+++ b/i18n/fur.po
@@ -595,7 +595,7 @@ msgstr ""
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:286
 #, fuzzy, javascript-format
 msgid "RESEND_TOKEN_WAIT_LBL${ seconds }"
-msgstr "Un nuovo SMS può essere richiesto in ${ cooldown } secondi."
+msgstr "Un nuovo SMS può essere richiesto in ${ seconds } secondi."
 
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:301
 msgid "RESEND_TOKEN"

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -598,7 +598,7 @@ msgstr ""
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:286
 #, fuzzy, javascript-format
 msgid "RESEND_TOKEN_WAIT_LBL${ seconds }"
-msgstr "Un nuovo SMS può essere richiesto in ${ cooldown } secondi."
+msgstr "Un nuovo SMS può essere richiesto in ${ seconds } secondi."
 
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:301
 msgid "RESEND_TOKEN"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -592,7 +592,7 @@ msgstr "Если вы не получили SMS-код, попробуйте з�
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:286
 #, fuzzy, javascript-format
 msgid "RESEND_TOKEN_WAIT_LBL${ seconds }"
-msgstr "Новое SMS может быть запрошено за ${ cooldown } секунд."
+msgstr "Новое SMS может быть запрошено за ${ seconds } секунд."
 
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:301
 msgid "RESEND_TOKEN"

--- a/i18n/sl.po
+++ b/i18n/sl.po
@@ -582,7 +582,7 @@ msgstr ""
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:286
 #, fuzzy, javascript-format
 msgid "RESEND_TOKEN_WAIT_LBL${ seconds }"
-msgstr "Nov SMS lahko zahtevate v ${ cooldown } sekundah."
+msgstr "Nov SMS lahko zahtevate v ${ seconds } sekundah."
 
 #: client/components/mobile-phone-verification/mobile-phone-verification.js:301
 msgid "RESEND_TOKEN"


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Description of Changes

Bug:

The mobile verification page was showing
"${undefined}" instead of the countdown time due mismatched variable in the translation string.

## Screenshot 

Before: 
<img width="1335" height="674" alt="Screenshot from 2025-12-22 18-23-45" src="https://github.com/user-attachments/assets/d2d3e797-8b95-4b8d-a8d4-13d4dbeac894" />


After: 
<img width="1335" height="674" alt="Screenshot from 2025-12-22 18-23-02" src="https://github.com/user-attachments/assets/5b88ecb4-aa80-4b24-a67e-91314f60ae6b" />


