### PR TITLE
[payment] Fixed payment flow with captive_portal_sync_auth #950

### DIFF
--- a/client/components/payment-status/index.js
+++ b/client/components/payment-status/index.js
@@ -12,6 +12,7 @@ const mapStateToProps = (state, ownProps) => {
     userData: conf.userData,
     settings: conf.settings,
     isAuthenticated: conf.isAuthenticated,
+    captivePortalSyncAuth: conf.components.captive_portal_sync_auth,
     cookies: ownProps.cookies,
     status: ownProps.status,
   };

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -121,7 +121,15 @@ export default class PaymentStatus extends React.Component {
   }
 
   paymentProceedHandler() {
-    const {authenticate, setUserData, userData, settings} = this.props;
+    const {
+      authenticate,
+      setUserData,
+      userData,
+      settings,
+      captivePortalSyncAuth,
+      cookies,
+      orgSlug,
+    } = this.props;
     // Payment gateway may require internet access.
     // Since, captive portal login is handled by the Status component,
     // the user is navigated to the "/status" for captive portal login
@@ -131,6 +139,13 @@ export default class PaymentStatus extends React.Component {
         ...userData,
         proceedToPayment: true,
       });
+      // Store proceedToPayment in cookie/localStorage for synchronous
+      // captive portal authentication where page reloads after form submission
+      if (captivePortalSyncAuth) {
+        const key = `${orgSlug}_proceedToPayment`;
+        localStorage.setItem(key, true);
+        cookies.set(key, true, {path: "/", maxAge: 60});
+      }
     }
     authenticate(true);
   }
@@ -228,6 +243,7 @@ PaymentStatus.propTypes = {
   page: PropTypes.object,
   logout: PropTypes.func.isRequired,
   cookies: PropTypes.instanceOf(Cookies).isRequired,
+  captivePortalSyncAuth: PropTypes.bool,
   settings: PropTypes.shape({
     payment_requires_internet: PropTypes.bool,
   }).isRequired,

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -244,6 +244,37 @@ describe("Test <PaymentStatus /> cases", () => {
     });
   });
 
+  it("should store proceedToPayment in cookie when captivePortalSyncAuth is enabled", async () => {
+    // When both payment_requires_internet and captivePortalSyncAuth are enabled,
+    // proceedToPayment should be stored in cookies/localStorage to persist across page reload
+    validateToken.mockReturnValue(true);
+
+    const cookies = new Cookies();
+    props = createTestProps({
+      userData: {...responseData, is_verified: false},
+      params: {status: "draft"},
+      cookies,
+      captivePortalSyncAuth: true,
+    });
+    props.settings.payment_requires_internet = true;
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    const payProcButton = wrapper
+      .find("Link.button.full")
+      .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
+      .first();
+    payProcButton.simulate("click");
+    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith({
+      ...responseData,
+      is_verified: false,
+      proceedToPayment: true,
+    });
+    expect(cookies.get("default_proceedToPayment")).toBe(true);
+    expect(localStorage.getItem("default_proceedToPayment")).toBe("true");
+    localStorage.removeItem("default_proceedToPayment");
+  });
+
   it("should redirect to status if success but unverified", async () => {
     const spyToast = jest.spyOn(toast, "success");
     props = createTestProps({

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -253,13 +253,23 @@ export default class Status extends React.Component {
       setUserData,
       statusPage,
       internetMode,
+      captivePortalSyncAuth,
+      cookies,
     } = this.props;
     const {setLoading} = this.context;
     // if the user needs bank card verification,
     // redirect to payment page and stop here
     if (needsVerify("bank_card", userData, settings)) {
       // avoid redirect loop from proceed to payment
-      if (settings.payment_requires_internet && userData.proceedToPayment) {
+      // resolve proceedToPayment from cookies/localStorage for synchronous
+      // captive portal authentication where page reloads after form submission
+      const proceedToPayment = this.resolveStoredValue(
+        captivePortalSyncAuth,
+        `${orgSlug}_proceedToPayment`,
+        userData.proceedToPayment,
+        cookies,
+      );
+      if (settings.payment_requires_internet && proceedToPayment) {
         // reset proceedToPayment
         setUserData({
           ...userData,


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

When both payment_requires_internet and captive_portal_sync_auth are enabled, the payment flow was not working properly. Users were redirected to /payment/draft instead of /payment/process after captive portal login.

The issue was that proceedToPayment flag was lost during page reload caused by synchronous captive portal form submission. The fix persists proceedToPayment in cookies/localStorage (similar to mustLogin) so it survives the page reload.

Changes:
- Added captivePortalSyncAuth to payment-status component props
- Store proceedToPayment in cookie/localStorage when captivePortalSyncAuth is enabled
- Resolve proceedToPayment from cookie/localStorage in status component finalOperations
- Added comprehensive test coverage for the fix

Fixes #950