### PR TITLE
[test] Make add-org interactive test catch config creation regressions

### DIFF
--- a/config/__tests__/add-org.test.js
+++ b/config/__tests__/add-org.test.js
@@ -26,6 +26,64 @@ const validData = {
   assets_confirm: false,
 };
 
+const interactiveData = {
+  ...validData,
+  name: "Interactive Test Organization",
+  uuid: "interactive-test-uuid",
+  secret_key: "interactive-test-secret",
+};
+
+const interactiveRunner = `
+  const fs = require("fs");
+  const path = require("path");
+  const response = JSON.parse(process.argv[1]);
+  const outputPath = path.resolve(
+    "organizations",
+    response.slug,
+    \`\${response.slug}.yml\`,
+  );
+
+  process.on("uncaughtException", (error) => {
+    console.error(error);
+    process.exit(1);
+  });
+
+  process.on("unhandledRejection", (error) => {
+    console.error(error);
+    process.exit(1);
+  });
+
+  const inquirerPath = require.resolve("inquirer");
+  require.cache[inquirerPath] = {
+    id: inquirerPath,
+    filename: inquirerPath,
+    loaded: true,
+    exports: {prompt: async () => response},
+  };
+
+  process.argv = ["node", path.resolve("config/add-org.js")];
+  require(path.resolve("config/add-org.js"));
+
+  const start = Date.now();
+  const waitForOutput = () => {
+    if (fs.existsSync(outputPath)) process.exit(0);
+    if (Date.now() - start > 5000) {
+      console.error("Timed out waiting for interactive config creation");
+      process.exit(1);
+    }
+    setTimeout(waitForOutput, 50);
+  };
+
+  waitForOutput();
+`;
+
+const runInteractiveAddOrg = (response) =>
+  spawnSync("node", ["-e", interactiveRunner, JSON.stringify(response)], {
+    encoding: "utf-8",
+    cwd: path.resolve(__dirname, "../.."),
+    timeout: 10000,
+  });
+
 describe("add-org command", () => {
   const cleanTestOrgDir = () => {
     if (fs.existsSync(testOrgDir)) {
@@ -79,6 +137,17 @@ describe("add-org command", () => {
     );
     expect(result.status).not.toBe(0);
     expect(result.stderr).toMatch(/already exists/);
+  });
+
+  it("runs interactively and creates config from prompt answers", () => {
+    const result = runInteractiveAddOrg(interactiveData);
+    expect(result.status).toBe(0);
+    expect(fs.existsSync(testOrgConfig)).toBe(true);
+    const config = yaml.load(fs.readFileSync(testOrgConfig, "utf8"));
+    expect(config.name).toBe(interactiveData.name);
+    expect(config.slug).toBe(interactiveData.slug);
+    expect(config.server.uuid).toBe(interactiveData.uuid);
+    expect(config.server.secret_key).toBe(interactiveData.secret_key);
   });
 
   it("runs interactively and creates config (smoke test)", () => {


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [ ] I have updated the documentation.

## Reference to Existing Issue

Closes #880.

## Description of Changes

The existing interactive add-org test was only a smoke test, so commenting out
`createConfiguration(response)` in `createConfigurationWithPrompts()` still left
the focused test suite green.

This updates `config/__tests__/add-org.test.js` to add a regression test that:

- runs the interactive CLI path with mocked prompt answers
- checks that the organization config file is created
- verifies key YAML fields from the prompt data

The existing smoke test is kept and no application code is changed.

## Verification

- `yarn jest config/__tests__/add-org.test.js --runInBand`
- `./run-qa-checks`
- confirmed the new test fails if `createConfiguration(response)` is commented out
- `yarn test --runInBand` was compared against untouched `origin/master`; the observed login/header failures are preexisting and unrelated to this change

## Screenshot

N/A - test-only change
