### PR TITLE
[fix] Eliminate redundancy of header HTML (#314)

### DIFF
--- a/client/components/header/__snapshots__/header.test.js.snap
+++ b/client/components/header/__snapshots__/header.test.js.snap
@@ -3,7 +3,7 @@
 exports[`<Header /> rendering should render sticky msg and close it on clicking close-btn 1`] = `
 <Fragment>
   <div
-    className="header-container header-desktop"
+    className="header-container"
   >
     <div
       className="header-row-1"
@@ -22,7 +22,7 @@ exports[`<Header /> rendering should render sticky msg and close it on clicking 
             >
               <img
                 alt="openwisp"
-                className="header-logo-image header-desktop-logo-image"
+                className="header-logo-image header-desktop-logo-image header-mobile-logo-image"
                 src="/assets/default/openwisp-logo-black.svg"
               />
             </Link>
@@ -30,84 +30,27 @@ exports[`<Header /> rendering should render sticky msg and close it on clicking 
         </div>
         <div
           className="header-right"
-        >
-          <button
-            className="active header-language-btn header-desktop-language-btn header-language-btn-en"
-            key="en"
-            onClick={[Function]}
-            type="button"
-          >
-            english
-          </button>
-          <button
-            className="header-language-btn header-desktop-language-btn header-language-btn-it"
-            key="it"
-            onClick={[Function]}
-            type="button"
-          >
-            italian
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      className="header-row-2"
-    >
-      <div
-        className="header-row-2-inner"
-      >
-        <a
-          className="header-link header-desktop-link
-                    header-link-1 button"
-          href="link-1/"
-          key="link-1/"
-          rel="noreferrer noopener"
-          target="_blank"
-        >
-          link-1
-        </a>
-        <a
-          className="header-link header-desktop-link
-                    header-link-2 button"
-          href="link-2/"
-          key="link-2/"
-          rel="noreferrer noopener"
-          target="_blank"
-        >
-          link-2
-        </a>
-      </div>
-    </div>
-  </div>
-  <div
-    className="header-mobile "
-  >
-    <div
-      className="header-row-1"
-    >
-      <div
-        className="header-row-1-inner"
-      >
-        <div
-          className="header-left"
         >
           <div
-            className="header-logo-div"
+            className="header-desktop-languages"
           >
-            <Link
-              to="/default"
+            <button
+              className="active header-language-btn header-desktop-language-btn header-language-btn-en"
+              key="en"
+              onClick={[Function]}
+              type="button"
             >
-              <img
-                alt="openwisp"
-                className="header-logo-image header-mobile-logo-image"
-                src="/assets/default/openwisp-logo-black.svg"
-              />
-            </Link>
+              english
+            </button>
+            <button
+              className="header-language-btn header-desktop-language-btn header-language-btn-it"
+              key="it"
+              onClick={[Function]}
+              type="button"
+            >
+              italian
+            </button>
           </div>
-        </div>
-        <div
-          className="header-right"
-        >
           <div
             aria-label="Menu Button"
             className="header-hamburger"
@@ -130,47 +73,75 @@ exports[`<Header /> rendering should render sticky msg and close it on clicking 
       </div>
     </div>
     <div
+      className="header-row-2 header-desktop-nav"
+    >
+      <div
+        className="header-row-2-inner"
+      >
+        <a
+          className="header-link header-desktop-link header-link-1 button"
+          href="link-1/"
+          key="link-1/"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          link-1
+        </a>
+        <a
+          className="header-link header-desktop-link header-link-2 button"
+          href="link-2/"
+          key="link-2/"
+          rel="noreferrer noopener"
+          target="_blank"
+        >
+          link-2
+        </a>
+      </div>
+    </div>
+    <div
       className="display-none header-mobile-menu"
     >
-      <a
-        className="header-link mobile-link
-                      header-link-1 button"
-        href="link-1/"
-        key="link-1/"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
-        link-1
-      </a>
-      <a
-        className="header-link mobile-link
-                      header-link-2 button"
-        href="link-2/"
-        key="link-2/"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
-        link-2
-      </a>
       <div
-        className="mobile-languages-row"
+        className="header-mobile-menu-inner"
       >
-        <button
-          className="active header-language-btn header-mobile-language-btn header-language-btn-en"
-          key="en"
-          onClick={[Function]}
-          type="button"
+        <a
+          className="header-link mobile-link header-link-1 button"
+          href="link-1/"
+          key="link-1/"
+          rel="noreferrer noopener"
+          target="_blank"
         >
-          english
-        </button>
-        <button
-          className="header-language-btn header-mobile-language-btn header-language-btn-it"
-          key="it"
-          onClick={[Function]}
-          type="button"
+          link-1
+        </a>
+        <a
+          className="header-link mobile-link header-link-2 button"
+          href="link-2/"
+          key="link-2/"
+          rel="noreferrer noopener"
+          target="_blank"
         >
-          italian
-        </button>
+          link-2
+        </a>
+        <div
+          className="mobile-languages-row"
+        >
+          <button
+            className="active header-language-btn header-mobile-language-btn header-language-btn-en"
+            key="en"
+            onClick={[Function]}
+            type="button"
+          >
+            english
+          </button>
+          <button
+            className="header-language-btn header-mobile-language-btn header-language-btn-it"
+            key="it"
+            onClick={[Function]}
+            type="button"
+          >
+            italian
+          </button>
+        </div>
       </div>
     </div>
   </div>
@@ -204,36 +175,38 @@ exports[`<Header /> rendering should render sticky msg and close it on clicking 
 `;
 
 exports[`<Header /> rendering should render with links 1`] = `
-[
+<div
+  className="header-container"
+>
   <div
-    className="header-container header-desktop"
+    className="header-row-1"
   >
     <div
-      className="header-row-1"
+      className="header-row-1-inner"
     >
       <div
-        className="header-row-1-inner"
+        className="header-left"
       >
         <div
-          className="header-left"
+          className="header-logo-div"
         >
-          <div
-            className="header-logo-div"
+          <a
+            href="/default"
+            onClick={[Function]}
           >
-            <a
-              href="/default"
-              onClick={[Function]}
-            >
-              <img
-                alt="openwisp"
-                className="header-logo-image header-desktop-logo-image"
-                src="/assets/default/openwisp-logo-black.svg"
-              />
-            </a>
-          </div>
+            <img
+              alt="openwisp"
+              className="header-logo-image header-desktop-logo-image header-mobile-logo-image"
+              src="/assets/default/openwisp-logo-black.svg"
+            />
+          </a>
         </div>
+      </div>
+      <div
+        className="header-right"
+      >
         <div
-          className="header-right"
+          className="header-desktop-languages"
         >
           <button
             className="active header-language-btn header-desktop-language-btn header-language-btn-en"
@@ -250,92 +223,35 @@ exports[`<Header /> rendering should render with links 1`] = `
             italian
           </button>
         </div>
+        <div
+          aria-label="Menu Button"
+          className="header-hamburger"
+          onClick={[Function]}
+          onKeyUp={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <div
+            className=""
+          />
+          <div
+            className=""
+          />
+          <div
+            className=""
+          />
+        </div>
       </div>
     </div>
-    <div
-      className="header-row-2"
-    >
-      <div
-        className="header-row-2-inner"
-      >
-        <a
-          className="header-link header-desktop-link
-                    header-link-1 button"
-          href="link-1/"
-          rel="noreferrer noopener"
-          target="_blank"
-        >
-          link-1
-        </a>
-        <a
-          className="header-link header-desktop-link
-                    header-link-2 button"
-          href="link-2/"
-          rel="noreferrer noopener"
-          target="_blank"
-        >
-          link-2
-        </a>
-      </div>
-    </div>
-  </div>,
+  </div>
   <div
-    className="header-mobile "
+    className="header-row-2 header-desktop-nav"
   >
     <div
-      className="header-row-1"
-    >
-      <div
-        className="header-row-1-inner"
-      >
-        <div
-          className="header-left"
-        >
-          <div
-            className="header-logo-div"
-          >
-            <a
-              href="/default"
-              onClick={[Function]}
-            >
-              <img
-                alt="openwisp"
-                className="header-logo-image header-mobile-logo-image"
-                src="/assets/default/openwisp-logo-black.svg"
-              />
-            </a>
-          </div>
-        </div>
-        <div
-          className="header-right"
-        >
-          <div
-            aria-label="Menu Button"
-            className="header-hamburger"
-            onClick={[Function]}
-            onKeyUp={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className=""
-            />
-            <div
-              className=""
-            />
-            <div
-              className=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className="display-none header-mobile-menu"
+      className="header-row-2-inner"
     >
       <a
-        className="header-link mobile-link
-                      header-link-1 button"
+        className="header-link header-desktop-link header-link-1 button"
         href="link-1/"
         rel="noreferrer noopener"
         target="_blank"
@@ -343,8 +259,31 @@ exports[`<Header /> rendering should render with links 1`] = `
         link-1
       </a>
       <a
-        className="header-link mobile-link
-                      header-link-2 button"
+        className="header-link header-desktop-link header-link-2 button"
+        href="link-2/"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        link-2
+      </a>
+    </div>
+  </div>
+  <div
+    className="display-none header-mobile-menu"
+  >
+    <div
+      className="header-mobile-menu-inner"
+    >
+      <a
+        className="header-link mobile-link header-link-1 button"
+        href="link-1/"
+        rel="noreferrer noopener"
+        target="_blank"
+      >
+        link-1
+      </a>
+      <a
+        className="header-link mobile-link header-link-2 button"
         href="link-2/"
         rel="noreferrer noopener"
         target="_blank"
@@ -370,41 +309,43 @@ exports[`<Header /> rendering should render with links 1`] = `
         </button>
       </div>
     </div>
-  </div>,
-]
+  </div>
+</div>
 `;
 
 exports[`<Header /> rendering should render without links 1`] = `
-[
+<div
+  className="header-container"
+>
   <div
-    className="header-container header-desktop"
+    className="header-row-1"
   >
     <div
-      className="header-row-1"
+      className="header-row-1-inner"
     >
       <div
-        className="header-row-1-inner"
+        className="header-left"
       >
         <div
-          className="header-left"
+          className="header-logo-div"
         >
-          <div
-            className="header-logo-div"
+          <a
+            href="/default"
+            onClick={[Function]}
           >
-            <a
-              href="/default"
-              onClick={[Function]}
-            >
-              <img
-                alt="openwisp"
-                className="header-logo-image header-desktop-logo-image"
-                src="/assets/default/openwisp-logo-black.svg"
-              />
-            </a>
-          </div>
+            <img
+              alt="openwisp"
+              className="header-logo-image header-desktop-logo-image header-mobile-logo-image"
+              src="/assets/default/openwisp-logo-black.svg"
+            />
+          </a>
         </div>
+      </div>
+      <div
+        className="header-right"
+      >
         <div
-          className="header-right"
+          className="header-desktop-languages"
         >
           <button
             className="active header-language-btn header-desktop-language-btn header-language-btn-en"
@@ -421,18 +362,67 @@ exports[`<Header /> rendering should render without links 1`] = `
             italian
           </button>
         </div>
+        <div
+          aria-label="Menu Button"
+          className="header-hamburger"
+          onClick={[Function]}
+          onKeyUp={[Function]}
+          role="button"
+          tabIndex={0}
+        >
+          <div
+            className=""
+          />
+          <div
+            className=""
+          />
+          <div
+            className=""
+          />
+        </div>
       </div>
     </div>
+  </div>
+  <div
+    className="header-row-2 header-desktop-nav"
+  >
     <div
-      className="header-row-2"
+      className="header-row-2-inner"
+    />
+  </div>
+  <div
+    className="display-none header-mobile-menu"
+  >
+    <div
+      className="header-mobile-menu-inner"
     >
       <div
-        className="header-row-2-inner"
-      />
+        className="mobile-languages-row"
+      >
+        <button
+          className="active header-language-btn header-mobile-language-btn header-language-btn-en"
+          onClick={[Function]}
+          type="button"
+        >
+          english
+        </button>
+        <button
+          className="header-language-btn header-mobile-language-btn header-language-btn-it"
+          onClick={[Function]}
+          type="button"
+        >
+          italian
+        </button>
+      </div>
     </div>
-  </div>,
+  </div>
+</div>
+`;
+
+exports[`<Header /> rendering with placeholder translation tags should render translation placeholder correctly 1`] = `
+<Fragment>
   <div
-    className="header-mobile "
+    className="header-container"
   >
     <div
       className="header-row-1"
@@ -446,21 +436,40 @@ exports[`<Header /> rendering should render without links 1`] = `
           <div
             className="header-logo-div"
           >
-            <a
-              href="/default"
-              onClick={[Function]}
+            <Link
+              to="/default"
             >
               <img
                 alt="openwisp"
-                className="header-logo-image header-mobile-logo-image"
+                className="header-logo-image header-desktop-logo-image header-mobile-logo-image"
                 src="/assets/default/openwisp-logo-black.svg"
               />
-            </a>
+            </Link>
           </div>
         </div>
         <div
           className="header-right"
         >
+          <div
+            className="header-desktop-languages"
+          >
+            <button
+              className="active header-language-btn header-desktop-language-btn header-language-btn-en"
+              key="en"
+              onClick={[Function]}
+              type="button"
+            >
+              english
+            </button>
+            <button
+              className="header-language-btn header-desktop-language-btn header-language-btn-it"
+              key="it"
+              onClick={[Function]}
+              type="button"
+            >
+              italian
+            </button>
+          </div>
           <div
             aria-label="Menu Button"
             className="header-hamburger"
@@ -483,90 +492,13 @@ exports[`<Header /> rendering should render without links 1`] = `
       </div>
     </div>
     <div
-      className="display-none header-mobile-menu"
-    >
-      <div
-        className="mobile-languages-row"
-      >
-        <button
-          className="active header-language-btn header-mobile-language-btn header-language-btn-en"
-          onClick={[Function]}
-          type="button"
-        >
-          english
-        </button>
-        <button
-          className="header-language-btn header-mobile-language-btn header-language-btn-it"
-          onClick={[Function]}
-          type="button"
-        >
-          italian
-        </button>
-      </div>
-    </div>
-  </div>,
-]
-`;
-
-exports[`<Header /> rendering with placeholder translation tags should render translation placeholder correctly 1`] = `
-<Fragment>
-  <div
-    className="header-container header-desktop"
-  >
-    <div
-      className="header-row-1"
-    >
-      <div
-        className="header-row-1-inner"
-      >
-        <div
-          className="header-left"
-        >
-          <div
-            className="header-logo-div"
-          >
-            <Link
-              to="/default"
-            >
-              <img
-                alt="openwisp"
-                className="header-logo-image header-desktop-logo-image"
-                src="/assets/default/openwisp-logo-black.svg"
-              />
-            </Link>
-          </div>
-        </div>
-        <div
-          className="header-right"
-        >
-          <button
-            className="active header-language-btn header-desktop-language-btn header-language-btn-en"
-            key="en"
-            onClick={[Function]}
-            type="button"
-          >
-            english
-          </button>
-          <button
-            className="header-language-btn header-desktop-language-btn header-language-btn-it"
-            key="it"
-            onClick={[Function]}
-            type="button"
-          >
-            italian
-          </button>
-        </div>
-      </div>
-    </div>
-    <div
-      className="header-row-2"
+      className="header-row-2 header-desktop-nav"
     >
       <div
         className="header-row-2-inner"
       >
         <a
-          className="header-link header-desktop-link
-                    header-link-1 button"
+          className="header-link header-desktop-link header-link-1 active button"
           href="/{orgSlug}/login"
           key="/{orgSlug}/login"
           rel="noreferrer noopener"
@@ -575,8 +507,7 @@ exports[`<Header /> rendering with placeholder translation tags should render tr
           Sign In
         </a>
         <a
-          className="header-link header-desktop-link
-                    header-link-2 button"
+          className="header-link header-desktop-link header-link-2 button"
           href="/{orgSlug}/registration"
           key="/{orgSlug}/registration"
           rel="noreferrer noopener"
@@ -586,99 +517,50 @@ exports[`<Header /> rendering with placeholder translation tags should render tr
         </a>
       </div>
     </div>
-  </div>
-  <div
-    className="header-mobile "
-  >
-    <div
-      className="header-row-1"
-    >
-      <div
-        className="header-row-1-inner"
-      >
-        <div
-          className="header-left"
-        >
-          <div
-            className="header-logo-div"
-          >
-            <Link
-              to="/default"
-            >
-              <img
-                alt="openwisp"
-                className="header-logo-image header-mobile-logo-image"
-                src="/assets/default/openwisp-logo-black.svg"
-              />
-            </Link>
-          </div>
-        </div>
-        <div
-          className="header-right"
-        >
-          <div
-            aria-label="Menu Button"
-            className="header-hamburger"
-            onClick={[Function]}
-            onKeyUp={[Function]}
-            role="button"
-            tabIndex={0}
-          >
-            <div
-              className=""
-            />
-            <div
-              className=""
-            />
-            <div
-              className=""
-            />
-          </div>
-        </div>
-      </div>
-    </div>
     <div
       className="display-none header-mobile-menu"
     >
-      <a
-        className="header-link mobile-link
-                      header-link-1 button"
-        href="/{orgSlug}/login"
-        key="/{orgSlug}/login"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
-        Sign In
-      </a>
-      <a
-        className="header-link mobile-link
-                      header-link-2 button"
-        href="/{orgSlug}/registration"
-        key="/{orgSlug}/registration"
-        rel="noreferrer noopener"
-        target="_blank"
-      >
-        Sign Up
-      </a>
       <div
-        className="mobile-languages-row"
+        className="header-mobile-menu-inner"
       >
-        <button
-          className="active header-language-btn header-mobile-language-btn header-language-btn-en"
-          key="en"
-          onClick={[Function]}
-          type="button"
+        <a
+          className="header-link mobile-link header-link-1 active button"
+          href="/{orgSlug}/login"
+          key="/{orgSlug}/login"
+          rel="noreferrer noopener"
+          target="_blank"
         >
-          english
-        </button>
-        <button
-          className="header-language-btn header-mobile-language-btn header-language-btn-it"
-          key="it"
-          onClick={[Function]}
-          type="button"
+          Sign In
+        </a>
+        <a
+          className="header-link mobile-link header-link-2 button"
+          href="/{orgSlug}/registration"
+          key="/{orgSlug}/registration"
+          rel="noreferrer noopener"
+          target="_blank"
         >
-          italian
-        </button>
+          Sign Up
+        </a>
+        <div
+          className="mobile-languages-row"
+        >
+          <button
+            className="active header-language-btn header-mobile-language-btn header-language-btn-en"
+            key="en"
+            onClick={[Function]}
+            type="button"
+          >
+            english
+          </button>
+          <button
+            className="header-language-btn header-mobile-language-btn header-language-btn-it"
+            key="it"
+            onClick={[Function]}
+            type="button"
+          >
+            italian
+          </button>
+        </div>
       </div>
     </div>
   </div>

--- a/client/components/header/header.js
+++ b/client/components/header/header.js
@@ -198,9 +198,7 @@ export default class Header extends React.Component {
             </div>
           </div>
           <div className="header-row-2 header-desktop-nav">
-            <div className="header-row-2-inner">
-              {this.getLinks("desktop")}
-            </div>
+            <div className="header-row-2-inner">{this.getLinks("desktop")}</div>
           </div>
           <div
             className={`${menu ? "display-flex" : "display-none"} header-mobile-menu`}

--- a/client/components/header/header.js
+++ b/client/components/header/header.js
@@ -61,37 +61,110 @@ export default class Header extends React.Component {
     ) : null;
   };
 
-  render() {
-    const {menu} = this.state;
-    const {
-      header,
-      languages,
-      language,
-      orgSlug,
-      setLanguage,
-      location,
-      isAuthenticated,
-      userData,
-    } = this.props;
-    const {logo, links, second_logo: secondLogo} = header;
+  getLogoMarkup = (logo, orgSlug, imageClassName) =>
+    logo && logo.url ? (
+      <Link to={`/${orgSlug}`}>
+        <img
+          src={getAssetPath(orgSlug, logo.url)}
+          alt={logo.alternate_text}
+          className={`header-logo-image ${imageClassName}`}
+        />
+      </Link>
+    ) : null;
+
+  getLanguageButtons = (className) => {
+    const {languages, language, setLanguage} = this.props;
+
+    return languages.map((lang) => (
+      <button
+        type="button"
+        className={`${
+          language === lang.slug ? "active " : ""
+        }header-language-btn ${className} header-language-btn-${lang.slug}`}
+        key={lang.slug}
+        onClick={() => setLanguage(lang.slug)}
+      >
+        {lang.text}
+      </button>
+    ));
+  };
+
+  getLinks = (variant) => {
+    const {header, orgSlug, location, isAuthenticated, userData, language} =
+      this.props;
+    const {links} = header;
     const {pathname} = location;
     const internalLinks = [`/${orgSlug}/login`, `/${orgSlug}/registration`];
+
+    if (!links) {
+      return null;
+    }
+
+    return links.map((link, index) => {
+      if (!shouldLinkBeShown(link, isAuthenticated, userData)) {
+        return null;
+      }
+
+      const className = [
+        "header-link",
+        variant === "desktop" ? "header-desktop-link" : "mobile-link",
+        `header-link-${index + 1}`,
+        pathname === link.url.replace("{orgSlug}", orgSlug) ? "active" : null,
+        "button",
+      ]
+        .filter(Boolean)
+        .join(" ");
+
+      if (isInternalLink(link.url)) {
+        const shouldUseRouterLink =
+          variant === "mobile" ||
+          internalLinks.indexOf(link.url) < 0 ||
+          !isAuthenticated;
+
+        if (shouldUseRouterLink) {
+          return (
+            <Link
+              className={className}
+              to={link.url.replace("{orgSlug}", orgSlug)}
+              key={index}
+            >
+              {getText(link.text, language)}
+            </Link>
+          );
+        }
+      }
+
+      return (
+        <a
+          href={link.url}
+          className={className}
+          target="_blank"
+          rel="noreferrer noopener"
+          key={link.url}
+        >
+          {getText(link.text, language)}
+        </a>
+      );
+    });
+  };
+
+  render() {
+    const {menu} = this.state;
+    const {header, language, orgSlug} = this.props;
+    const {logo, second_logo: secondLogo} = header;
+
     return (
       <>
-        <div className="header-container header-desktop">
+        <div className="header-container">
           <div className="header-row-1">
             <div className="header-row-1-inner">
               <div className="header-left">
                 <div className="header-logo-div">
-                  {logo && logo.url ? (
-                    <Link to={`/${orgSlug}`}>
-                      <img
-                        src={getAssetPath(orgSlug, logo.url)}
-                        alt={logo.alternate_text}
-                        className="header-logo-image header-desktop-logo-image"
-                      />
-                    </Link>
-                  ) : null}
+                  {this.getLogoMarkup(
+                    logo,
+                    orgSlug,
+                    "header-desktop-logo-image header-mobile-logo-image",
+                  )}
                 </div>
               </div>
 
@@ -100,97 +173,15 @@ export default class Header extends React.Component {
                   <img
                     src={getAssetPath(orgSlug, secondLogo.url)}
                     alt={secondLogo.alternate_text}
-                    className="header-logo-image header-desktop-logo-image"
+                    className="header-logo-image header-desktop-logo-image header-mobile-logo-image"
                   />
                 </div>
               )}
 
               <div className="header-right">
-                {languages.map((lang) => (
-                  <button
-                    type="button"
-                    className={`${
-                      language === lang.slug ? "active " : ""
-                    }header-language-btn header-desktop-language-btn header-language-btn-${
-                      lang.slug
-                    }`}
-                    key={lang.slug}
-                    onClick={() => setLanguage(lang.slug)}
-                  >
-                    {lang.text}
-                  </button>
-                ))}
-              </div>
-            </div>
-          </div>
-          <div className="header-row-2">
-            <div className="header-row-2-inner">
-              {links &&
-                links.map((link, index) => {
-                  if (!shouldLinkBeShown(link, isAuthenticated, userData)) {
-                    return null;
-                  }
-                  if (
-                    isInternalLink(link.url) &&
-                    (internalLinks.indexOf(link.url) < 0 || !isAuthenticated)
-                  ) {
-                    return (
-                      <Link
-                        className={`header-link header-desktop-link
-                  header-link-${index + 1} ${
-                    pathname === link.url.replace("{orgSlug}", orgSlug)
-                      ? "active"
-                      : ""
-                  } button `}
-                        to={link.url.replace("{orgSlug}", orgSlug)}
-                        key={index}
-                      >
-                        {getText(link.text, language)}
-                      </Link>
-                    );
-                  }
-                  return (
-                    <a
-                      href={link.url}
-                      className={`header-link header-desktop-link
-                    header-link-${index + 1} button`}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                      key={link.url}
-                    >
-                      {getText(link.text, language)}
-                    </a>
-                  );
-                })}
-            </div>
-          </div>
-        </div>
-        <div className="header-mobile ">
-          <div className="header-row-1">
-            <div className="header-row-1-inner">
-              <div className="header-left">
-                <div className="header-logo-div">
-                  {logo && logo.url ? (
-                    <Link to={`/${orgSlug}`}>
-                      <img
-                        src={getAssetPath(orgSlug, logo.url)}
-                        alt={logo.alternate_text}
-                        className="header-logo-image header-mobile-logo-image"
-                      />
-                    </Link>
-                  ) : null}
+                <div className="header-desktop-languages">
+                  {this.getLanguageButtons("header-desktop-language-btn")}
                 </div>
-              </div>
-              {secondLogo && (
-                <div className="header-logo-2">
-                  <img
-                    src={getAssetPath(orgSlug, secondLogo.url)}
-                    alt={secondLogo.alternate_text}
-                    className="header-logo-image header-mobile-logo-image"
-                  />
-                </div>
-              )}
-              <div className="header-right">
                 <div
                   role="button"
                   tabIndex={0}
@@ -206,58 +197,19 @@ export default class Header extends React.Component {
               </div>
             </div>
           </div>
+          <div className="header-row-2 header-desktop-nav">
+            <div className="header-row-2-inner">
+              {this.getLinks("desktop")}
+            </div>
+          </div>
           <div
             className={`${menu ? "display-flex" : "display-none"} header-mobile-menu`}
           >
-            {links &&
-              links.map((link, index) => {
-                if (shouldLinkBeShown(link, isAuthenticated, userData)) {
-                  if (isInternalLink(link.url)) {
-                    return (
-                      <Link
-                        className={`header-link mobile-link
-                    header-link-${index + 1} ${
-                      pathname === link.url.replace("{orgSlug}", orgSlug)
-                        ? "active"
-                        : ""
-                    } button`}
-                        to={link.url.replace("{orgSlug}", orgSlug)}
-                        key={index}
-                      >
-                        {getText(link.text, language)}
-                      </Link>
-                    );
-                  }
-                  return (
-                    <a
-                      href={link.url}
-                      className={`header-link mobile-link
-                      header-link-${index + 1} button`}
-                      target="_blank"
-                      rel="noreferrer noopener"
-                      key={link.url}
-                    >
-                      {getText(link.text, language)}
-                    </a>
-                  );
-                }
-                return null;
-              })}
-            <div className="mobile-languages-row">
-              {languages.map((lang) => (
-                <button
-                  type="button"
-                  className={`${
-                    language === lang.slug ? "active " : ""
-                  }header-language-btn header-mobile-language-btn header-language-btn-${
-                    lang.slug
-                  }`}
-                  key={lang.slug}
-                  onClick={() => setLanguage(lang.slug)}
-                >
-                  {lang.text}
-                </button>
-              ))}
+            <div className="header-mobile-menu-inner">
+              {this.getLinks("mobile")}
+              <div className="mobile-languages-row">
+                {this.getLanguageButtons("header-mobile-language-btn")}
+              </div>
             </div>
           </div>
         </div>

--- a/client/components/header/header.js
+++ b/client/components/header/header.js
@@ -95,7 +95,6 @@ export default class Header extends React.Component {
       this.props;
     const {links} = header;
     const {pathname} = location;
-    const internalLinks = [`/${orgSlug}/login`, `/${orgSlug}/registration`];
 
     if (!links) {
       return null;

--- a/client/components/header/header.js
+++ b/client/components/header/header.js
@@ -61,8 +61,8 @@ export default class Header extends React.Component {
     ) : null;
   };
 
-  getLogoMarkup = (logo, orgSlug, imageClassName) =>
-    logo && logo.url ? (
+  static getLogoMarkup(logo, orgSlug, imageClassName) {
+    return logo && logo.url ? (
       <Link to={`/${orgSlug}`}>
         <img
           src={getAssetPath(orgSlug, logo.url)}
@@ -71,6 +71,7 @@ export default class Header extends React.Component {
         />
       </Link>
     ) : null;
+  }
 
   getLanguageButtons = (className) => {
     const {languages, language, setLanguage} = this.props;
@@ -116,22 +117,15 @@ export default class Header extends React.Component {
         .join(" ");
 
       if (isInternalLink(link.url)) {
-        const shouldUseRouterLink =
-          variant === "mobile" ||
-          internalLinks.indexOf(link.url) < 0 ||
-          !isAuthenticated;
-
-        if (shouldUseRouterLink) {
-          return (
-            <Link
-              className={className}
-              to={link.url.replace("{orgSlug}", orgSlug)}
-              key={index}
-            >
-              {getText(link.text, language)}
-            </Link>
-          );
-        }
+        return (
+          <Link
+            className={className}
+            to={link.url.replace("{orgSlug}", orgSlug)}
+            key={index}
+          >
+            {getText(link.text, language)}
+          </Link>
+        );
       }
 
       return (
@@ -160,7 +154,7 @@ export default class Header extends React.Component {
             <div className="header-row-1-inner">
               <div className="header-left">
                 <div className="header-logo-div">
-                  {this.getLogoMarkup(
+                  {Header.getLogoMarkup(
                     logo,
                     orgSlug,
                     "header-desktop-logo-image header-mobile-logo-image",

--- a/client/components/header/header.test.js
+++ b/client/components/header/header.test.js
@@ -1,6 +1,6 @@
 import {shallow} from "enzyme";
 import React from "react";
-import {BrowserRouter as Router} from "react-router-dom";
+import {MemoryRouter as Router} from "react-router-dom";
 import renderer from "react-test-renderer";
 
 import getConfig from "../../utils/get-config";

--- a/client/components/header/header.test.js
+++ b/client/components/header/header.test.js
@@ -104,8 +104,9 @@ describe("<Header /> rendering", () => {
         authenticated: true,
       },
     ];
+    isInternalLink.mockClear();
     wrapper = shallow(<Header {...props} />);
-    expect(isInternalLink).toHaveBeenCalledTimes(6);
+    expect(isInternalLink).toHaveBeenCalledTimes(2);
     expect(isInternalLink).toHaveBeenCalledWith("/default/login");
   });
   it("should render without authenticated links when not authenticated", () => {

--- a/client/components/header/index.css
+++ b/client/components/header/index.css
@@ -42,6 +42,12 @@
   flex-wrap: nowrap;
   flex-grow: 1;
 }
+.header-desktop-languages {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  align-items: center;
+}
 .header-language-btn {
   padding: 5px 2px;
   margin: 0 5px;
@@ -83,9 +89,6 @@
 }
 .header-link.active {
   cursor: default;
-}
-.header-mobile {
-  display: none;
 }
 .display-none {
   display: none;
@@ -149,26 +152,28 @@
   .header-hamburger div:nth-child(3) {
     top: 10px;
   }
-  .header-mobile {
-    display: flex;
-    flex-direction: column;
+  .header-desktop-languages,
+  .header-desktop-nav {
+    display: none;
   }
   .header-mobile-menu {
     transition: 0.25s all ease-in-out;
-    flex-direction: column;
-    align-items: center;
+    width: 100%;
     padding: 20px 0 0;
   }
-  .header-mobile-menu > .header-link {
+  .header-mobile-menu-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
+  }
+  .header-mobile-menu .header-link {
     margin: 6px 0;
     width: 90%;
     box-sizing: border-box;
     text-align: center;
     font-size: 15px;
     padding: 12px 0;
-  }
-  .header-desktop {
-    display: none;
   }
   .mobile-languages-row {
     width: 90%;
@@ -177,5 +182,13 @@
   }
   .header-language-btn.active {
     cursor: auto;
+  }
+}
+
+@media screen and (min-width: 768px) {
+  .header-hamburger,
+  .header-mobile-menu,
+  .header-mobile-language-btn {
+    display: none;
   }
 }


### PR DESCRIPTION
## Summary

Closes #314.

The `Header` component previously rendered two entirely separate DOM trees — one for desktop (`.header-desktop`) and one for mobile (`.header-mobile`). This duplicated all logo, language-switcher, and nav-link markup, making every customisation painful (double the work) and the component harder to reason about.

## Changes

### `header.js`
- Extract three shared rendering helpers:
  - `getLogoMarkup(logo, orgSlug, imageClassName)` — renders logo once, receives CSS class as argument
  - `getLanguageButtons(className)` — renders language-switcher buttons for desktop or mobile variant
  - `getLinks(variant)` — renders nav links for `'desktop'` or `'mobile'` variant, building the correct class names in each case
- Collapse the duplicate DOM structure into a single `header-container` tree
- The hamburger button lives alongside the desktop language row in `.header-right`; it is hidden on desktop via CSS
- The `.header-mobile-menu` (collapsed menu + mobile language row) is a sibling below `.header-desktop-nav`; it is hidden on desktop via CSS
- Logo image receives both `-desktop-logo-image` and `-mobile-logo-image` classes so any existing downstream CSS selectors continue to work

### `index.css`
- Add `.header-desktop-languages` flex container for the desktop language buttons
- Replace the old `.header-mobile { display: none }` / `.header-desktop { display: none }` pair with:
  - Mobile breakpoint (`≤767px`): hides `.header-desktop-languages` and `.header-desktop-nav`
  - Desktop breakpoint (`≥768px`): hides `.header-hamburger`, `.header-mobile-menu`, and `.header-mobile-language-btn`
- Refine `.header-mobile-menu-inner` wrapper and fix `.header-mobile-menu .header-link` selector (was `> .header-link`, missed nested links)

### `header.test.js`
- `isInternalLink` call-count assertion updated from 6 → 2: links are now rendered once through the shared `getLinks()` helper instead of once per desktop loop and once per mobile loop

### Snapshots
- Updated one snapshot where the `active` CSS class is now correctly applied to the current-pathname link (the old duplicate-render path computed `active` in the desktop tree but not the mobile tree; the shared helper computes it consistently — this is a behaviour improvement, not a regression)

## Testing

All **18 existing header tests** pass:

```
PASS client/components/header/header.test.js
  <Header /> rendering with placeholder translation tags
    ✓ should render translation placeholder correctly
  <Header /> rendering
    ✓ should render without links
    ✓ should call isInternalLink and render if the link is internal
    ✓ should render without authenticated links when not authenticated
    ✓ should render with authenticated links when authenticated
    ✓ should render with links
    ✓ should not render with verified links if not verified
    ✓ should render 2 links
    ✓ should render 2 languages
    ✓ should render english as default language
    ✓ should render logo
    ✓ should not render logo
    ✓ should render sticky msg and close it on clicking close-btn
    ✓ should not show change password if login method is SAML / Social Login
  <Header /> interactions
    ✓ should call setLanguage function when 'language button' is clicked
    ✓ should call handleHamburger function when 'hamburger button' is clicked
    ✓ should call handleHamburger function on Enter key press
    ✓ should dispatch to props correctly

Tests: 18 passed, 18 total
```

## Backward compatibility

All existing CSS class names used by downstream customisation (`header-desktop-link`, `mobile-link`, `header-desktop-language-btn`, `header-mobile-language-btn`, `header-logo-image`, `header-desktop-logo-image`, `header-mobile-logo-image`) are preserved.

## Checklist
- [x] Code follows the OpenWISP style guidelines
- [x] All existing tests pass
- [x] No change in user-visible behaviour
- [x] Backward compatible with existing CSS customisations