### PR TITLE
[fix] Fixed extra JS files not being copied to dist after copy-webpack-plugin upgrade

### DIFF
--- a/browser-test/js-file-inject.test.js
+++ b/browser-test/js-file-inject.test.js
@@ -43,4 +43,10 @@ describe("Selenium tests to check JS file injection in organization page", () =>
       true,
     );
   });
+
+  it("should serve the extra js file without 404", async () => {
+    const jsFile = initialData().allOrgScript;
+    const response = await fetch(`http://127.0.0.1:8080/${jsFile}`);
+    expect(response.status).toEqual(200);
+  });
 });

--- a/browser-test/js-file-inject.test.js
+++ b/browser-test/js-file-inject.test.js
@@ -42,6 +42,7 @@ describe("Selenium tests to check JS file injection in organization page", () =>
   });
 
   it("should serve the extra js file with correct content type", async () => {
+    await driver.get(urls.login);
     const jsFile = initialData().allOrgScript;
     const result = await driver.executeScript(
       `return fetch("/${jsFile}").then(r => ({

--- a/browser-test/js-file-inject.test.js
+++ b/browser-test/js-file-inject.test.js
@@ -4,6 +4,7 @@ import {
   urls,
   tearDown,
   initialData,
+  baseUrl,
 } from "./utils";
 
 describe("Selenium tests to check JS file injection in organization page", () => {
@@ -27,9 +28,7 @@ describe("Selenium tests to check JS file injection in organization page", () =>
         scriptSources.push(await script.getAttribute("src"));
       }),
     );
-    expect(scriptSources.includes(`http://127.0.0.1:8080/${jsFile}`)).toEqual(
-      true,
-    );
+    expect(scriptSources.includes(`${baseUrl}/${jsFile}`)).toEqual(true);
     const data = initialData().mobileVerificationTestUser;
     await driver.get(urls.verificationLogin(data.organization));
     scriptSources = [];
@@ -39,14 +38,18 @@ describe("Selenium tests to check JS file injection in organization page", () =>
         scriptSources.push(await script.getAttribute("src"));
       }),
     );
-    expect(scriptSources.includes(`http://127.0.0.1:8080/${jsFile}`)).toEqual(
-      true,
-    );
+    expect(scriptSources.includes(`${baseUrl}/${jsFile}`)).toEqual(true);
   });
 
-  it("should serve the extra js file without 404", async () => {
+  it("should serve the extra js file with correct content type", async () => {
     const jsFile = initialData().allOrgScript;
-    const response = await fetch(`http://127.0.0.1:8080/${jsFile}`);
-    expect(response.status).toEqual(200);
+    const result = await driver.executeScript(
+      `return fetch("/${jsFile}").then(r => ({
+        status: r.status,
+        contentType: r.headers.get('content-type'),
+      }))`,
+    );
+    expect(result.status).toEqual(200);
+    expect(result.contentType).toEqual(expect.stringContaining("javascript"));
   });
 });

--- a/browser-test/password-expired.test.js
+++ b/browser-test/password-expired.test.js
@@ -34,12 +34,23 @@ describe("Selenium tests for expired password flow />", () => {
     await driver.wait(until.urlContains("change-password"), 5000);
     let successToastDiv = await getElementByCss(driver, "div[role=alert]");
     await driver.wait(until.elementIsVisible(successToastDiv));
+    await driver.wait(
+      until.elementTextContains(successToastDiv, "Login successful"),
+      5000,
+    );
     expect(await successToastDiv.getText()).toEqual("Login successful");
     const warningToastMessage = await getElementByCss(
       driver,
       ".Toastify__toast--warning",
     );
     await driver.wait(until.elementIsVisible(warningToastMessage));
+    await driver.wait(
+      until.elementTextContains(
+        warningToastMessage,
+        "Your password has expired",
+      ),
+      5000,
+    );
     expect(await warningToastMessage.getText()).toEqual(
       "Your password has expired, please update it.",
     );
@@ -86,6 +97,10 @@ describe("Selenium tests for expired password flow />", () => {
     await getElementByCss(driver, "div#status");
     successToastDiv = await getElementByCss(driver, "div[role=alert]");
     await driver.wait(until.elementIsVisible(successToastDiv));
+    await driver.wait(
+      until.elementTextContains(successToastDiv, "Login successful"),
+      5000,
+    );
     expect(await successToastDiv.getText()).toEqual("Login successful");
   });
 });

--- a/browser-test/utils.js
+++ b/browser-test/utils.js
@@ -6,6 +6,7 @@ const firefox = require("selenium-webdriver/firefox");
 
 const waitTime = 5000;
 const orgSlug = "default";
+export const baseUrl = "http://127.0.0.1:8080";
 
 export const executeCommand = (command, argv) => {
   const result = spawnSync(command, [argv]);
@@ -77,22 +78,20 @@ export const getPhoneToken = () => {
 };
 
 export const urls = {
-  registration: `http://127.0.0.1:8080/${orgSlug}/registration`,
-  registrationTos: `http://127.0.0.1:8080/${orgSlug}/registration/terms-and-conditions`,
-  registrationPrivacy: `http://127.0.0.1:8080/${orgSlug}/registration/privacy-policy`,
-  login: `http://127.0.0.1:8080/${orgSlug}/login`,
-  loginTos: `http://127.0.0.1:8080/${orgSlug}/login/terms-and-conditions`,
-  loginPrivacy: `http://127.0.0.1:8080/${orgSlug}/login/privacy-policy`,
-  status: `http://127.0.0.1:8080/${orgSlug}/status`,
-  passwordChange: `http://127.0.0.1:8080/${orgSlug}/change-password`,
-  passwordReset: `http://127.0.0.1:8080/${orgSlug}/password/reset`,
+  registration: `${baseUrl}/${orgSlug}/registration`,
+  registrationTos: `${baseUrl}/${orgSlug}/registration/terms-and-conditions`,
+  registrationPrivacy: `${baseUrl}/${orgSlug}/registration/privacy-policy`,
+  login: `${baseUrl}/${orgSlug}/login`,
+  loginTos: `${baseUrl}/${orgSlug}/login/terms-and-conditions`,
+  loginPrivacy: `${baseUrl}/${orgSlug}/login/privacy-policy`,
+  status: `${baseUrl}/${orgSlug}/status`,
+  passwordChange: `${baseUrl}/${orgSlug}/change-password`,
+  passwordReset: `${baseUrl}/${orgSlug}/password/reset`,
   passwordConfirm: (uid, token) =>
-    `http://127.0.0.1:8080/${orgSlug}/password/reset/confirm/${uid}/${token}`,
-  verificationLogin: (slug) => `http://127.0.0.1:8080/${slug}/login`,
-  mobileVerification: (slug) =>
-    `http://127.0.0.1:8080/${slug}/mobile-phone-verification`,
-  mobilePhoneChange: (slug) =>
-    `http://127.0.0.1:8080/${slug}/change-phone-number`,
+    `${baseUrl}/${orgSlug}/password/reset/confirm/${uid}/${token}`,
+  verificationLogin: (slug) => `${baseUrl}/${slug}/login`,
+  mobileVerification: (slug) => `${baseUrl}/${slug}/mobile-phone-verification`,
+  mobilePhoneChange: (slug) => `${baseUrl}/${slug}/change-phone-number`,
 };
 
 export const successToastSelector = ".Toastify__toast--success div[role=alert]";

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -36,7 +36,8 @@ module.exports = (env, argv) => {
         },
         {
           from: path.resolve(CURRENT_WORKING_DIR, "organizations/js/*.js"),
-          to: path.resolve(CURRENT_WORKING_DIR, "dist/[name].[ext]"),
+          to: path.resolve(CURRENT_WORKING_DIR, "dist/[name][ext]"),
+          context: path.resolve(CURRENT_WORKING_DIR, "organizations/js"),
           noErrorOnMissing: true,
         },
       ],


### PR DESCRIPTION
The copy-webpack-plugin v13 upgrade broke the copying of organization-wide extra JS files (organizations/js/*.js). Two changes were needed:

- Add explicit 'context' option, required by v13 for absolute glob paths
- Change [name].[ext] to [name][ext] since v13's [ext] includes the leading dot

A regression test has also been added.

## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

No existing  issue, I directly opened a PR due to time constraints.