### PR TITLE
[tests] Avoid installing openwisp-monitoring in selenium tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "**/requirements*.txt"
 
@@ -102,6 +103,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
+          python-version: "3.13"
           cache: "pip"
           cache-dependency-path: "**/requirements*.txt"
 
@@ -129,9 +131,12 @@ jobs:
         run: |
           cd openwisp-radius
           pip install -U pip setuptools wheel
-          pip install -U -e ".[saml]"
-          pip install -U -r requirements-test.txt
-          pip install -U "Django~=5.2.0"
+          pip install "Django~=5.2.0"
+          # remove some test dependencies not used here
+          sed -i '/openwisp-monitoring/d' requirements-test.txt
+          sed -i '/mock-ssh-server/d' requirements-test.txt
+          pip install -r requirements-test.txt
+          pip install -e ".[saml]"
           ./tests/manage.py migrate
 
       - name: Creating configuration of organization (supports mobile verification)


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Not needed (small cleanup).

## Description of Changes

Avoid installing openwisp-monitoring in selenium tests, not needed.
