### PR TITLE
[fix] Show payment failure page for plan-upgrade payments #1145

### DIFF
--- a/client/actions/logout.js
+++ b/client/actions/logout.js
@@ -8,7 +8,11 @@ const logout = (cookies, orgSlug, userAutoLogin = false) => {
     cookies.remove(`${orgSlug}_macaddr`, {path: "/"});
     sessionStorage.clear();
   }
-  [`${orgSlug}_mustLogin`, `${orgSlug}_mustLogout`].forEach((element) => {
+  [
+    `${orgSlug}_mustLogin`,
+    `${orgSlug}_mustLogout`,
+    `${orgSlug}_captivePortalLogoutOnly`,
+  ].forEach((element) => {
     cookies.remove(element, {path: "/"});
     localStorage.removeItem(element);
   });

--- a/client/components/payment-status/index.js
+++ b/client/components/payment-status/index.js
@@ -12,6 +12,7 @@ const mapStateToProps = (state, ownProps) => {
     userData: conf.userData,
     settings: conf.settings,
     isAuthenticated: conf.isAuthenticated,
+    captivePortalSyncAuth: conf.components.captive_portal_sync_auth,
     cookies: ownProps.cookies,
     status: ownProps.status,
   };

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -10,6 +10,8 @@ import Loader from "../../utils/loader";
 import Contact from "../contact-box";
 import validateToken from "../../utils/validate-token";
 import handleLogout from "../../utils/handle-logout";
+import cancelUpgradePlan from "../../utils/cancel-upgrade-plan";
+import logError from "../../utils/log-error";
 
 export default class PaymentStatus extends React.Component {
   constructor(props) {
@@ -65,10 +67,39 @@ export default class PaymentStatus extends React.Component {
     }
   }
 
-  // a user who gives up on a plan upgrade keeps the plan they already
-  // paid for, so they are sent back to the status page without logging out
-  backToStatus = () => {
-    const {orgSlug, navigate} = this.props;
+  // a user who gives up on a plan upgrade keeps their existing plan,
+  // so they are sent back to the status page without logging out.
+  // The backend must cancel the pending upgrade order and stale
+  // upgrade/login flags must be cleared, otherwise status.js can still
+  // bounce the user back to payment/draft.
+  backToStatus = async () => {
+    const {orgSlug, navigate, setUserData, userData, language} = this.props;
+    try {
+      const response = await cancelUpgradePlan(
+        orgSlug,
+        userData.auth_token || userData.key,
+        language,
+      );
+      setUserData({
+        ...userData,
+        ...response,
+        auth_token: response.auth_token || response.key || userData.auth_token,
+        proceedToPayment: false,
+        mustLogin: undefined,
+      });
+    } catch (error) {
+      if (!error.response || error.response.status !== 404) {
+        toast.error(t`ERR_OCCUR`);
+        logError(error, "Error while cancelling plan upgrade");
+      }
+      setUserData({
+        ...userData,
+        in_upgrade: false,
+        proceedToPayment: false,
+        payment_url: null,
+        mustLogin: undefined,
+      });
+    }
     navigate(`/${orgSlug}/status`);
   };
 

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -84,6 +84,7 @@ export default class PaymentStatus extends React.Component {
         ...userData,
         ...response,
         auth_token: response.auth_token || response.key || userData.auth_token,
+        in_upgrade: false,
         proceedToPayment: false,
         mustLogin: undefined,
         mustLogout: true,
@@ -151,7 +152,6 @@ export default class PaymentStatus extends React.Component {
     }
 
     // draft case
-    // if (isAuthenticated === false && status === "draft") {
     if (status === "draft") {
       return this.renderDraft(isDraftUpgrade);
     }
@@ -162,7 +162,9 @@ export default class PaymentStatus extends React.Component {
       return redirectToStatus();
     }
 
-    // Show loader while validateToken resolves in_upgrade state on cold reload
+    // Prevent a brief render of the non-upgrade failed page while validateToken
+    // is resolving on a cold reload. The draft flow doesn't need this because it
+    // doesn't branch on in_upgrade until the payment-proceed step.
     if (status === "failed" && isTokenValid === null) {
       return <Loader />;
     }
@@ -255,7 +257,7 @@ export default class PaymentStatus extends React.Component {
   }
 
   renderFailed(isFailedUpgrade = false) {
-    const {orgSlug, userData} = this.props;
+    const {orgSlug, userData, settings} = this.props;
     // User might have exhausted the temporary session quota while completing
     // the payment. Thus, we need to login them back in the captive portal
     // before directing them to the payment gateway.
@@ -264,6 +266,10 @@ export default class PaymentStatus extends React.Component {
       : `/${orgSlug}/payment/draft`;
     // No retry when upgrade payment attempts exhausted (no payment_url)
     const showRetry = !isFailedUpgrade || Boolean(userData.payment_url);
+    // Only re-run the captive portal login when internet is actually required;
+    // otherwise the retry is a plain navigation to the payment gateway.
+    const needsPortalLogin =
+      isFailedUpgrade && settings.payment_requires_internet;
     // failed payment case
     return (
       <div className="container content">
@@ -278,7 +284,7 @@ export default class PaymentStatus extends React.Component {
                     className="button full"
                     to={retryUrl}
                     onClick={
-                      isFailedUpgrade ? this.paymentProceedHandler : undefined
+                      needsPortalLogin ? this.paymentProceedHandler : undefined
                     }
                   >
                     {t`PAY_TRY_AGAIN_BTN`}

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -6,6 +6,7 @@ import {Link, Navigate} from "react-router-dom";
 import {toast} from "react-toastify";
 import {t} from "ttag";
 import LoadingContext from "../../utils/loading-context";
+import Loader from "../../utils/loader";
 import Contact from "../contact-box";
 import validateToken from "../../utils/validate-token";
 import handleLogout from "../../utils/handle-logout";
@@ -123,6 +124,13 @@ export default class PaymentStatus extends React.Component {
     if (isTokenValid === true && status === "success" && isVerified === true) {
       toast.success(t`PAY_SUCCESS`);
       return redirectToStatus();
+    }
+
+    // isTokenValid is still null while validateToken() is resolving, so
+    // in_upgrade (and therefore isFailedUpgrade) isn't reliable yet on a cold
+    // reload; show a loader instead of flashing the wrong failed-page variant
+    if (status === "failed" && isTokenValid === null) {
+      return <Loader />;
     }
 
     return this.renderFailed(isFailedUpgrade);

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -72,11 +72,13 @@ export default class PaymentStatus extends React.Component {
     }
   }
 
-  // a user who gives up on a plan upgrade keeps their existing plan,
-  // so they are sent back to the status page without logging out.
+  // A user who gives up on a plan upgrade keeps their existing plan.
   // The backend must cancel the pending upgrade order and stale
   // upgrade/login flags must be cleared, otherwise status.js can still
-  // bounce the user back to payment/draft.
+  // bounce the user back to payment/draft. The captive portal session
+  // established to reach the payment gateway was granted under a
+  // temporary/limited group for this upgrade attempt, so it must be
+  // logged out too, letting the user reconnect under their actual plan.
   backToStatus = async () => {
     const {orgSlug, navigate, setUserData, userData, language} = this.props;
     try {
@@ -91,6 +93,7 @@ export default class PaymentStatus extends React.Component {
         auth_token: response.auth_token || response.key || userData.auth_token,
         proceedToPayment: false,
         mustLogin: undefined,
+        mustLogout: true,
       });
     } catch (error) {
       if (!error.response || error.response.status !== 404) {
@@ -103,6 +106,7 @@ export default class PaymentStatus extends React.Component {
         proceedToPayment: false,
         payment_url: null,
         mustLogin: undefined,
+        mustLogout: true,
       });
     }
     navigate(`/${orgSlug}/status`);

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -187,9 +187,11 @@ export default class PaymentStatus extends React.Component {
     if (settings.payment_requires_internet) {
       setUserData({
         ...userData,
+        mustLogin: true,
         proceedToPayment: true,
       });
       // Persist so it survives page reload during sync captive portal auth
+      storeValue(captivePortalSyncAuth, `${orgSlug}_mustLogin`, true, cookies);
       storeValue(
         captivePortalSyncAuth,
         `${orgSlug}_proceedToPayment`,
@@ -200,12 +202,17 @@ export default class PaymentStatus extends React.Component {
     authenticate(true);
   }
 
-  renderDraft(isDraftUpgrade = false) {
-    const {orgSlug, page = {}, settings} = this.props;
-    const {timeout = 5, max_attempts: maxAttempts = 3} = page;
-    const payProceedUrl = settings.payment_requires_internet
+  getProceedUrl() {
+    const {orgSlug, settings} = this.props;
+    return settings.payment_requires_internet
       ? `/${orgSlug}/status`
       : `/${orgSlug}/payment/process`;
+  }
+
+  renderDraft(isDraftUpgrade = false) {
+    const {page = {}} = this.props;
+    const {timeout = 5, max_attempts: maxAttempts = 3} = page;
+    const payProceedUrl = this.getProceedUrl();
 
     return (
       <div className="container content">
@@ -249,8 +256,11 @@ export default class PaymentStatus extends React.Component {
 
   renderFailed(isFailedUpgrade = false) {
     const {orgSlug, userData} = this.props;
+    // User might have exhausted the temporary session quota while completing
+    // the payment. Thus, we need to login them back in the captive portal
+    // before directing them to the payment gateway.
     const retryUrl = isFailedUpgrade
-      ? `/${orgSlug}/payment/process`
+      ? this.getProceedUrl()
       : `/${orgSlug}/payment/draft`;
     // No retry when upgrade payment attempts exhausted (no payment_url)
     const showRetry = !isFailedUpgrade || Boolean(userData.payment_url);
@@ -264,7 +274,13 @@ export default class PaymentStatus extends React.Component {
               <div className="row payment-status-row-2">{t`PAY_SUB_H`}</div>
               {showRetry && (
                 <div className="row payment-status-row-3">
-                  <Link className="button full" to={retryUrl}>
+                  <Link
+                    className="button full"
+                    to={retryUrl}
+                    onClick={
+                      isFailedUpgrade ? this.paymentProceedHandler : undefined
+                    }
+                  >
                     {t`PAY_TRY_AGAIN_BTN`}
                   </Link>
                 </div>

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -48,12 +48,17 @@ export default class PaymentStatus extends React.Component {
     const {method, is_verified: isVerified} = userData;
     // flag user to repeat login in order to restart session with new radius group
     if (status === "success" && method === "bank_card" && isVerified === true) {
-      setUserData({
-        ...userData,
-        mustLogin: !settings.payment_requires_internet,
-        mustLogout: settings.payment_requires_internet,
-        repeatLogin: settings.payment_requires_internet,
-      });
+      // when the captive portal supports CoA, the backend transitions the
+      // session to the new radius group transparently, so no logout/login
+      // cycle is needed here
+      if (!settings.captive_portal_supports_coa) {
+        setUserData({
+          ...userData,
+          mustLogin: !settings.payment_requires_internet,
+          mustLogout: settings.payment_requires_internet,
+          repeatLogin: settings.payment_requires_internet,
+        });
+      }
     } else if (
       status === "draft" &&
       // User will need internet access for completing the payment whether
@@ -291,6 +296,7 @@ PaymentStatus.propTypes = {
   cookies: PropTypes.instanceOf(Cookies).isRequired,
   settings: PropTypes.shape({
     payment_requires_internet: PropTypes.bool,
+    captive_portal_supports_coa: PropTypes.bool,
   }).isRequired,
   params: PropTypes.shape({
     status: PropTypes.string,

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -48,9 +48,7 @@ export default class PaymentStatus extends React.Component {
     const {method, is_verified: isVerified} = userData;
     // flag user to repeat login in order to restart session with new radius group
     if (status === "success" && method === "bank_card" && isVerified === true) {
-      // when the captive portal supports CoA, the backend transitions the
-      // session to the new radius group transparently, so no logout/login
-      // cycle is needed here
+      // Skip logout/login cycle if CoA handles session group updates transparently
       if (!settings.captive_portal_supports_coa) {
         setUserData({
           ...userData,
@@ -61,8 +59,7 @@ export default class PaymentStatus extends React.Component {
       }
     } else if (
       status === "draft" &&
-      // User will need internet access for completing the payment whether
-      // they are registering with a paid plan or upgrade to one.
+      // Payment completion needs internet for both new registrations and upgrades
       (userData.in_upgrade || (method === "bank_card" && isVerified === false))
     ) {
       setUserData({
@@ -72,13 +69,7 @@ export default class PaymentStatus extends React.Component {
     }
   }
 
-  // A user who gives up on a plan upgrade keeps their existing plan.
-  // The backend must cancel the pending upgrade order and stale
-  // upgrade/login flags must be cleared, otherwise status.js can still
-  // bounce the user back to payment/draft. The captive portal session
-  // established to reach the payment gateway was granted under a
-  // temporary/limited group for this upgrade attempt, so it must be
-  // logged out too, letting the user reconnect under their actual plan.
+  // Abandon upgrade: cancel order, clear flags, reconnect under current plan
   backToStatus = async () => {
     const {orgSlug, navigate, setUserData, userData, language} = this.props;
     try {
@@ -94,6 +85,7 @@ export default class PaymentStatus extends React.Component {
         proceedToPayment: false,
         mustLogin: undefined,
         mustLogout: true,
+        captivePortalLogoutOnly: true,
       });
     } catch (error) {
       if (!error.response || error.response.status !== 404) {
@@ -107,6 +99,7 @@ export default class PaymentStatus extends React.Component {
         payment_url: null,
         mustLogin: undefined,
         mustLogout: true,
+        captivePortalLogoutOnly: true,
       });
     }
     navigate(`/${orgSlug}/status`);
@@ -135,16 +128,9 @@ export default class PaymentStatus extends React.Component {
     const redirectToStatus = () => <Navigate to={`/${orgSlug}/status`} />;
     const acceptedValues = ["success", "failed", "draft"];
     const {isTokenValid} = this.state;
-    // a user upgrading their plan keeps the registration method and the
-    // verified flag they already had, so the checks written for the bank
-    // card registration flow would send them away from this page
+    // Upgraders retain their existing registration state; bypass bank-card redirect guards
     const isFailedUpgrade = Boolean(inUpgrade) && status === "failed";
-    // a user upgrading their plan keeps the registration method and the
-    // verified flag they already had, so the draft page checks written for
-    // the bank card registration flow would otherwise send them away
     const isDraftUpgrade = Boolean(inUpgrade) && status === "draft";
-    // invalid status, not registered with bank card flow, or likely
-    // somebody opening this page by mistake
     const shouldRedirectToStatus =
       !acceptedValues.includes(status) ||
       (!inUpgrade && method && method !== "bank_card") ||
@@ -172,9 +158,7 @@ export default class PaymentStatus extends React.Component {
       return redirectToStatus();
     }
 
-    // isTokenValid is still null while validateToken() is resolving, so
-    // in_upgrade (and therefore isFailedUpgrade) isn't reliable yet on a cold
-    // reload; show a loader instead of flashing the wrong failed-page variant
+    // Show loader while validateToken resolves in_upgrade state on cold reload
     if (status === "failed" && isTokenValid === null) {
       return <Loader />;
     }
@@ -249,8 +233,7 @@ export default class PaymentStatus extends React.Component {
     const retryUrl = isFailedUpgrade
       ? `/${orgSlug}/payment/process`
       : `/${orgSlug}/payment/draft`;
-    // an upgrade which ran out of allowed payment attempts has no
-    // payment URL left to send the user to
+    // No retry when upgrade payment attempts exhausted (no payment_url)
     const showRetry = !isFailedUpgrade || Boolean(userData.payment_url);
     // failed payment case
     return (

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -12,6 +12,7 @@ import validateToken from "../../utils/validate-token";
 import handleLogout from "../../utils/handle-logout";
 import cancelUpgradePlan from "../../utils/cancel-upgrade-plan";
 import logError from "../../utils/log-error";
+import {storeValue, clearStoredValue} from "../../utils/synced-storage";
 
 export default class PaymentStatus extends React.Component {
   constructor(props) {
@@ -71,7 +72,8 @@ export default class PaymentStatus extends React.Component {
 
   // Abandon upgrade: cancel order, clear flags, reconnect under current plan
   backToStatus = async () => {
-    const {orgSlug, navigate, setUserData, userData, language} = this.props;
+    const {orgSlug, navigate, setUserData, userData, language, cookies} =
+      this.props;
     try {
       const response = await cancelUpgradePlan(
         orgSlug,
@@ -102,6 +104,8 @@ export default class PaymentStatus extends React.Component {
         captivePortalLogoutOnly: true,
       });
     }
+    // Clear persisted proceedToPayment flag
+    clearStoredValue(`${orgSlug}_proceedToPayment`, cookies);
     navigate(`/${orgSlug}/status`);
   };
 
@@ -167,7 +171,15 @@ export default class PaymentStatus extends React.Component {
   }
 
   paymentProceedHandler() {
-    const {authenticate, setUserData, userData, settings} = this.props;
+    const {
+      authenticate,
+      setUserData,
+      userData,
+      settings,
+      cookies,
+      orgSlug,
+      captivePortalSyncAuth,
+    } = this.props;
     // Payment gateway may require internet access.
     // Since, captive portal login is handled by the Status component,
     // the user is navigated to the "/status" for captive portal login
@@ -177,6 +189,13 @@ export default class PaymentStatus extends React.Component {
         ...userData,
         proceedToPayment: true,
       });
+      // Persist so it survives page reload during sync captive portal auth
+      storeValue(
+        captivePortalSyncAuth,
+        `${orgSlug}_proceedToPayment`,
+        "true",
+        cookies,
+      );
     }
     authenticate(true);
   }
@@ -277,6 +296,7 @@ PaymentStatus.propTypes = {
   userData: PropTypes.object.isRequired,
   setUserData: PropTypes.func.isRequired,
   isAuthenticated: PropTypes.bool,
+  captivePortalSyncAuth: PropTypes.bool,
   authenticate: PropTypes.func.isRequired,
   page: PropTypes.object,
   logout: PropTypes.func.isRequired,

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -63,6 +63,13 @@ export default class PaymentStatus extends React.Component {
     }
   }
 
+  // a user who gives up on a plan upgrade keeps the plan they already
+  // paid for, so they are sent back to the status page without logging out
+  backToStatus = () => {
+    const {orgSlug, navigate} = this.props;
+    navigate(`/${orgSlug}/status`);
+  };
+
   logout = () => {
     const {logout, cookies, orgSlug, setUserData, userData, navigate} =
       this.props;
@@ -82,26 +89,27 @@ export default class PaymentStatus extends React.Component {
   render() {
     const {orgSlug, params, isAuthenticated, userData} = this.props;
     const {status} = params;
-    const {method, is_verified: isVerified} = userData;
+    const {method, is_verified: isVerified, in_upgrade: inUpgrade} = userData;
     const redirectToStatus = () => <Navigate to={`/${orgSlug}/status`} />;
     const acceptedValues = ["success", "failed", "draft"];
     const {isTokenValid} = this.state;
-
-    // not registered with bank card flow
-    if (
-      (method && method !== "bank_card") ||
-      !acceptedValues.includes(status)
-    ) {
-      return redirectToStatus();
-    }
-
-    // likely somebody opening this page by mistake
-    if (
+    // a user upgrading their plan keeps the registration method and the
+    // verified flag they already had, so the checks written for the bank
+    // card registration flow would send them away from this page
+    const isFailedUpgrade = Boolean(inUpgrade) && status === "failed";
+    // invalid status, not registered with bank card flow, or likely
+    // somebody opening this page by mistake
+    const shouldRedirectToStatus =
+      !acceptedValues.includes(status) ||
+      (!isFailedUpgrade && method && method !== "bank_card") ||
       (isAuthenticated === false && status !== "draft") ||
-      (["failed", "draft"].includes(status) && isVerified === true) ||
+      (!isFailedUpgrade &&
+        ["failed", "draft"].includes(status) &&
+        isVerified === true) ||
       (status === "success" && isVerified === false) ||
-      isTokenValid === false
-    ) {
+      isTokenValid === false;
+
+    if (shouldRedirectToStatus) {
       return redirectToStatus();
     }
 
@@ -117,7 +125,7 @@ export default class PaymentStatus extends React.Component {
       return redirectToStatus();
     }
 
-    return this.renderFailed();
+    return this.renderFailed(isFailedUpgrade);
   }
 
   paymentProceedHandler() {
@@ -182,8 +190,14 @@ export default class PaymentStatus extends React.Component {
     );
   }
 
-  renderFailed() {
-    const {orgSlug} = this.props;
+  renderFailed(isFailedUpgrade = false) {
+    const {orgSlug, userData} = this.props;
+    const retryUrl = isFailedUpgrade
+      ? `/${orgSlug}/payment/process`
+      : `/${orgSlug}/payment/draft`;
+    // an upgrade which ran out of allowed payment attempts has no
+    // payment URL left to send the user to
+    const showRetry = !isFailedUpgrade || Boolean(userData.payment_url);
     // failed payment case
     return (
       <div className="container content">
@@ -192,20 +206,22 @@ export default class PaymentStatus extends React.Component {
             <div className="inner">
               <h2 className="row payment-status-row-1">{t`PAY_FAIL`}</h2>
               <div className="row payment-status-row-2">{t`PAY_SUB_H`}</div>
-              <div className="row payment-status-row-3">
-                <Link className="button full" to={`/${orgSlug}/payment/draft`}>
-                  {t`PAY_TRY_AGAIN_BTN`}
-                </Link>
-              </div>
+              {showRetry && (
+                <div className="row payment-status-row-3">
+                  <Link className="button full" to={retryUrl}>
+                    {t`PAY_TRY_AGAIN_BTN`}
+                  </Link>
+                </div>
+              )}
 
               <div className="row payment-status-row-4">
                 <p>{t`PAY_GIVE_UP_TXT`}</p>
                 <button
                   type="button"
                   className="button full"
-                  onClick={this.logout}
+                  onClick={isFailedUpgrade ? this.backToStatus : this.logout}
                 >
-                  {t`PAY_GIVE_UP_BTN`}
+                  {isFailedUpgrade ? t`PAY_GO_BACK_BTN` : t`PAY_GIVE_UP_BTN`}
                 </button>
               </div>
             </div>

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -54,8 +54,9 @@ export default class PaymentStatus extends React.Component {
       });
     } else if (
       status === "draft" &&
-      method === "bank_card" &&
-      isVerified === false
+      // User will need internet access for completing the payment whether
+      // they are registering with a paid plan or upgrade to one.
+      (userData.in_upgrade || (method === "bank_card" && isVerified === false))
     ) {
       setUserData({
         ...userData,
@@ -98,13 +99,18 @@ export default class PaymentStatus extends React.Component {
     // verified flag they already had, so the checks written for the bank
     // card registration flow would send them away from this page
     const isFailedUpgrade = Boolean(inUpgrade) && status === "failed";
+    // a user upgrading their plan keeps the registration method and the
+    // verified flag they already had, so the draft page checks written for
+    // the bank card registration flow would otherwise send them away
+    const isDraftUpgrade = Boolean(inUpgrade) && status === "draft";
     // invalid status, not registered with bank card flow, or likely
     // somebody opening this page by mistake
     const shouldRedirectToStatus =
       !acceptedValues.includes(status) ||
-      (!isFailedUpgrade && method && method !== "bank_card") ||
+      (!inUpgrade && method && method !== "bank_card") ||
       (isAuthenticated === false && status !== "draft") ||
       (!isFailedUpgrade &&
+        !isDraftUpgrade &&
         ["failed", "draft"].includes(status) &&
         isVerified === true) ||
       (status === "success" && isVerified === false) ||
@@ -117,7 +123,7 @@ export default class PaymentStatus extends React.Component {
     // draft case
     // if (isAuthenticated === false && status === "draft") {
     if (status === "draft") {
-      return this.renderDraft();
+      return this.renderDraft(isDraftUpgrade);
     }
 
     // success case
@@ -151,7 +157,7 @@ export default class PaymentStatus extends React.Component {
     authenticate(true);
   }
 
-  renderDraft() {
+  renderDraft(isDraftUpgrade = false) {
     const {orgSlug, page = {}, settings} = this.props;
     const {timeout = 5, max_attempts: maxAttempts = 3} = page;
     const payProceedUrl = settings.payment_requires_internet
@@ -186,9 +192,9 @@ export default class PaymentStatus extends React.Component {
                 <button
                   type="button"
                   className="button full"
-                  onClick={this.logout}
+                  onClick={isDraftUpgrade ? this.backToStatus : this.logout}
                 >
-                  {t`PAY_GIVE_UP_BTN`}
+                  {isDraftUpgrade ? t`PAY_GO_BACK_BTN` : t`PAY_GIVE_UP_BTN`}
                 </button>
               </div>
             </div>

--- a/client/components/payment-status/payment-status.js
+++ b/client/components/payment-status/payment-status.js
@@ -83,15 +83,23 @@ export default class PaymentStatus extends React.Component {
       setUserData({
         ...userData,
         ...response,
-        auth_token: response.auth_token || response.key || userData.auth_token,
         in_upgrade: false,
         proceedToPayment: false,
+        payment_url: null,
         mustLogin: undefined,
         mustLogout: true,
         captivePortalLogoutOnly: true,
       });
     } catch (error) {
-      if (!error.response || error.response.status !== 404) {
+      // The API replies 404 when there is no pending upgrade order left to
+      // cancel, which is a no-op for the user rather than an error. A 404
+      // from our own server carries response_code NOT_FOUND and means the
+      // org slug is unknown, so keep surfacing that one.
+      const noPendingOrder =
+        error.response &&
+        error.response.status === 404 &&
+        (error.response.data || {}).response_code !== "NOT_FOUND";
+      if (!noPendingOrder) {
         toast.error(t`ERR_OCCUR`);
         logError(error, "Error while cancelling plan upgrade");
       }
@@ -151,6 +159,10 @@ export default class PaymentStatus extends React.Component {
       return redirectToStatus();
     }
 
+    if (isTokenValid === null) {
+      return <Loader />;
+    }
+
     // draft case
     if (status === "draft") {
       return this.renderDraft(isDraftUpgrade);
@@ -160,13 +172,6 @@ export default class PaymentStatus extends React.Component {
     if (isTokenValid === true && status === "success" && isVerified === true) {
       toast.success(t`PAY_SUCCESS`);
       return redirectToStatus();
-    }
-
-    // Prevent a brief render of the non-upgrade failed page while validateToken
-    // is resolving on a cold reload. The draft flow doesn't need this because it
-    // doesn't branch on in_upgrade until the payment-proceed step.
-    if (status === "failed" && isTokenValid === null) {
-      return <Loader />;
     }
 
     return this.renderFailed(isFailedUpgrade);
@@ -197,7 +202,7 @@ export default class PaymentStatus extends React.Component {
       storeValue(
         captivePortalSyncAuth,
         `${orgSlug}_proceedToPayment`,
-        "true",
+        true,
         cookies,
       );
     }

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -287,6 +287,93 @@ describe("Test <PaymentStatus /> cases", () => {
     });
   });
 
+  it("should persist proceedToPayment cookie for sync auth", async () => {
+    validateToken.mockReturnValue(true);
+    const mockCookiesSet = jest.fn();
+    const mockCookiesRemove = jest.fn();
+    const mockCookiesGet = jest.fn();
+    props = createTestProps({
+      userData: {...responseData, is_verified: false},
+      params: {status: "draft"},
+      captivePortalSyncAuth: true,
+      cookies: {
+        set: mockCookiesSet,
+        remove: mockCookiesRemove,
+        get: mockCookiesGet,
+      },
+    });
+    props.settings.payment_requires_internet = true;
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    const payProcButton = wrapper
+      .find("Link.button.full")
+      .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
+      .first();
+    payProcButton.simulate("click");
+    // Verify the cookie was set
+    expect(mockCookiesSet).toHaveBeenCalledWith(
+      "default_proceedToPayment",
+      "true",
+      {path: "/", maxAge: 60},
+    );
+    // Verify userData was updated with proceedToPayment
+    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({proceedToPayment: true}),
+    );
+  });
+
+  it("should not persist proceedToPayment when internet is not required", async () => {
+    validateToken.mockReturnValue(true);
+    const mockCookiesSet = jest.fn();
+    props = createTestProps({
+      userData: {...responseData, is_verified: false},
+      params: {status: "draft"},
+      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
+    });
+    props.settings.payment_requires_internet = false;
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    const payProcButton = wrapper
+      .find("Link.button.full")
+      .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
+      .first();
+    payProcButton.simulate("click");
+    // No cookie should be set: internet access isn't needed before payment
+    expect(mockCookiesSet).not.toHaveBeenCalled();
+    // userData should not be flagged with proceedToPayment either
+    expect(wrapper.instance().props.setUserData).not.toHaveBeenCalledWith(
+      expect.objectContaining({proceedToPayment: true}),
+    );
+  });
+
+  it("should not persist proceedToPayment cookie in async auth mode", async () => {
+    validateToken.mockReturnValue(true);
+    const mockCookiesSet = jest.fn();
+    props = createTestProps({
+      userData: {...responseData, is_verified: false},
+      params: {status: "draft"},
+      captivePortalSyncAuth: false,
+      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
+    });
+    props.settings.payment_requires_internet = true;
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    const payProcButton = wrapper
+      .find("Link.button.full")
+      .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
+      .first();
+    payProcButton.simulate("click");
+    // Async auth never reloads the page, so there is nothing to survive
+    // and the flag doesn't need to be persisted outside Redux.
+    expect(mockCookiesSet).not.toHaveBeenCalled();
+    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({proceedToPayment: true}),
+    );
+  });
+
   it("should redirect to status if success but unverified", async () => {
     const spyToast = jest.spyOn(toast, "success");
     props = createTestProps({
@@ -406,6 +493,44 @@ describe("Test <PaymentStatus /> cases", () => {
     });
     expect(props.navigate).toHaveBeenCalledWith("/default/status");
     expect(props.logout).not.toHaveBeenCalled();
+  });
+
+  it("should clear the persisted proceedToPayment flag when abandoning an upgrade", async () => {
+    const mockCookiesRemove = jest.fn();
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+      cookies: {
+        set: jest.fn(),
+        get: jest.fn(),
+        remove: mockCookiesRemove,
+      },
+    });
+    localStorage.setItem("default_proceedToPayment", "true");
+    validateToken.mockReturnValue(true);
+    cancelUpgradePlan.mockResolvedValue({
+      in_upgrade: false,
+      payment_url: null,
+    });
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    wrapper.find(".payment-status-row-4 .button").simulate("click", {});
+    await tick();
+    // Stale flag must be cleared, otherwise a later status reload could
+    // wrongly force the user back into the payment flow.
+    expect(mockCookiesRemove).toHaveBeenCalledWith("default_proceedToPayment", {
+      path: "/",
+    });
+    expect(localStorage.getItem("default_proceedToPayment")).toBeNull();
   });
 
   it("should hide the continue button if the payment url is not available", async () => {

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -227,6 +227,28 @@ describe("Test <PaymentStatus /> cases", () => {
     ]);
   });
 
+  it("does not force logout/relogin on success when captive portal supports CoA", async () => {
+    const spyToast = jest.spyOn(toast, "success");
+    props = createTestProps({
+      userData: {...responseData, is_verified: true},
+      params: {status: "success"},
+    });
+    props.settings.captive_portal_supports_coa = true;
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+      disableLifecycleMethods: true,
+    });
+    const comp = wrapper.instance();
+    comp.componentDidMount();
+    await tick();
+    expect(wrapper.find("Navigate").length).toEqual(1);
+    expect(wrapper.find("Navigate").props().to).toEqual("/default/status");
+    expect(spyToast.mock.calls.length).toBe(1);
+    expect(comp.props.logout).not.toHaveBeenCalled();
+    expect(comp.props.setUserData).not.toHaveBeenCalled();
+  });
+
   it("should set proceedToPayment in userData when navigating to /status", async () => {
     // If the payment requires internet, proceedToPayment should
     // be set to true in userData

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -14,12 +14,14 @@ import tick from "../../utils/tick";
 import validateToken from "../../utils/validate-token";
 import loadTranslation from "../../utils/load-translation";
 import cancelUpgradePlan from "../../utils/cancel-upgrade-plan";
+import logError from "../../utils/log-error";
 
 jest.mock("axios");
 jest.mock("../../utils/get-config");
 jest.mock("../../utils/validate-token");
 jest.mock("../../utils/load-translation");
 jest.mock("../../utils/cancel-upgrade-plan");
+jest.mock("../../utils/log-error");
 
 const defaultConfig = getConfig("default", true);
 const createTestProps = (props) => ({
@@ -245,15 +247,17 @@ describe("Test <PaymentStatus /> cases", () => {
     expect(comp.props.setUserData).not.toHaveBeenCalled();
   });
 
-  it("should set proceedToPayment in userData when navigating to /status", async () => {
+  it("should set proceedToPayment in userData and not persist it without sync auth", async () => {
     // If the payment requires internet, proceedToPayment should
     // be set to true in userData
     validateToken.mockReturnValue(true);
 
     // Test payment_requires_internet is set to false
+    let mockCookiesSet = jest.fn();
     props = createTestProps({
       userData: {...responseData, is_verified: false},
       params: {status: "draft"},
+      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
     });
     props.settings.payment_requires_internet = false;
     wrapper = shallow(<PaymentStatus {...props} />, {
@@ -265,11 +269,14 @@ describe("Test <PaymentStatus /> cases", () => {
       .first();
     payProcButton.simulate("click");
     expect(wrapper.instance().props.setUserData).not.toHaveBeenCalled();
+    expect(mockCookiesSet).not.toHaveBeenCalled();
 
-    // Test payment_requires_internet is set to true
+    // Test payment_requires_internet is set to true, without sync auth
+    mockCookiesSet = jest.fn();
     props = createTestProps({
       userData: {...responseData, is_verified: false},
       params: {status: "draft"},
+      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
     });
     props.settings.payment_requires_internet = true;
     wrapper = shallow(<PaymentStatus {...props} />, {
@@ -286,6 +293,9 @@ describe("Test <PaymentStatus /> cases", () => {
       mustLogin: true,
       proceedToPayment: true,
     });
+    // Async auth never reloads the page, so there is nothing to survive
+    // and the flag doesn't need to be persisted outside Redux.
+    expect(mockCookiesSet).not.toHaveBeenCalled();
   });
 
   it("should persist proceedToPayment cookie for sync auth", async () => {
@@ -319,57 +329,6 @@ describe("Test <PaymentStatus /> cases", () => {
       {path: "/", maxAge: 60},
     );
     // Verify userData was updated with proceedToPayment
-    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
-      expect.objectContaining({proceedToPayment: true}),
-    );
-  });
-
-  it("should not persist proceedToPayment when internet is not required", async () => {
-    validateToken.mockReturnValue(true);
-    const mockCookiesSet = jest.fn();
-    props = createTestProps({
-      userData: {...responseData, is_verified: false},
-      params: {status: "draft"},
-      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
-    });
-    props.settings.payment_requires_internet = false;
-    wrapper = shallow(<PaymentStatus {...props} />, {
-      context: loadingContextValue,
-    });
-    const payProcButton = wrapper
-      .find("Link.button.full")
-      .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
-      .first();
-    payProcButton.simulate("click");
-    // No cookie should be set: internet access isn't needed before payment
-    expect(mockCookiesSet).not.toHaveBeenCalled();
-    // userData should not be flagged with proceedToPayment either
-    expect(wrapper.instance().props.setUserData).not.toHaveBeenCalledWith(
-      expect.objectContaining({proceedToPayment: true}),
-    );
-  });
-
-  it("should not persist proceedToPayment cookie in async auth mode", async () => {
-    validateToken.mockReturnValue(true);
-    const mockCookiesSet = jest.fn();
-    props = createTestProps({
-      userData: {...responseData, is_verified: false},
-      params: {status: "draft"},
-      captivePortalSyncAuth: false,
-      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
-    });
-    props.settings.payment_requires_internet = true;
-    wrapper = shallow(<PaymentStatus {...props} />, {
-      context: loadingContextValue,
-    });
-    const payProcButton = wrapper
-      .find("Link.button.full")
-      .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
-      .first();
-    payProcButton.simulate("click");
-    // Async auth never reloads the page, so there is nothing to survive
-    // and the flag doesn't need to be persisted outside Redux.
-    expect(mockCookiesSet).not.toHaveBeenCalled();
     expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
       expect.objectContaining({proceedToPayment: true}),
     );
@@ -431,10 +390,16 @@ describe("Test <PaymentStatus /> cases", () => {
     expect(spyToast.mock.calls.length).toBe(0);
   });
 
-  it("should render failed state when a plan upgrade payment fails", async () => {
+  it("should not force captive portal login when retrying and payment does not require internet", async () => {
+    const mockCookiesSet = jest.fn();
     props = createTestProps({
       params: {status: "failed"},
-      settings: {subscriptions: true, mobile_phone_verification: true},
+      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: false,
+      },
       userData: {
         ...responseData,
         method: "mobile_phone",
@@ -453,32 +418,12 @@ describe("Test <PaymentStatus /> cases", () => {
     expect(
       wrapper.find(".payment-status-row-3 .button").at(0).props().to,
     ).toEqual("/default/payment/process");
-  });
-
-  it("should route failed-upgrade retry through /status when payment requires internet", async () => {
-    props = createTestProps({
-      params: {status: "failed"},
-      settings: {
-        subscriptions: true,
-        mobile_phone_verification: true,
-        payment_requires_internet: true,
-      },
-      userData: {
-        ...responseData,
-        method: "mobile_phone",
-        is_verified: true,
-        in_upgrade: true,
-        payment_url: "https://payment.example.com/pay/1",
-      },
-    });
-    validateToken.mockReturnValue(true);
-    wrapper = shallow(<PaymentStatus {...props} />, {
-      context: loadingContextValue,
-    });
-    await tick();
-    expect(
-      wrapper.find(".payment-status-row-3 .button").at(0).props().to,
-    ).toEqual("/default/status");
+    wrapper.find(".payment-status-row-3 .button").at(0).simulate("click");
+    expect(mockCookiesSet).not.toHaveBeenCalled();
+    expect(wrapper.instance().props.setUserData).not.toHaveBeenCalled();
+    // No captive portal login needed when internet is not required, so the
+    // retry is a plain navigation and paymentProceedHandler must not run.
+    expect(props.authenticate).not.toHaveBeenCalled();
   });
 
   it("should log into the captive portal when retrying a failed upgrade", async () => {
@@ -505,6 +450,9 @@ describe("Test <PaymentStatus /> cases", () => {
       context: loadingContextValue,
     });
     await tick();
+    expect(
+      wrapper.find(".payment-status-row-3 .button").at(0).props().to,
+    ).toEqual("/default/status");
     wrapper.find(".payment-status-row-3 .button").at(0).simulate("click");
     expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
       expect.objectContaining({mustLogin: true, proceedToPayment: true}),
@@ -519,81 +467,6 @@ describe("Test <PaymentStatus /> cases", () => {
       {path: "/", maxAge: 60},
     );
     expect(props.authenticate).toHaveBeenCalledWith(true);
-  });
-
-  it("should not force captive portal login when retrying and payment does not require internet", async () => {
-    const mockCookiesSet = jest.fn();
-    props = createTestProps({
-      params: {status: "failed"},
-      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
-      settings: {
-        subscriptions: true,
-        mobile_phone_verification: true,
-        payment_requires_internet: false,
-      },
-      userData: {
-        ...responseData,
-        method: "mobile_phone",
-        is_verified: true,
-        in_upgrade: true,
-        payment_url: "https://payment.example.com/pay/1",
-      },
-    });
-    validateToken.mockReturnValue(true);
-    wrapper = shallow(<PaymentStatus {...props} />, {
-      context: loadingContextValue,
-    });
-    await tick();
-    expect(
-      wrapper.find(".payment-status-row-3 .button").at(0).props().to,
-    ).toEqual("/default/payment/process");
-    wrapper.find(".payment-status-row-3 .button").at(0).simulate("click");
-    expect(mockCookiesSet).not.toHaveBeenCalled();
-    expect(wrapper.instance().props.setUserData).not.toHaveBeenCalled();
-    // No captive portal login needed when internet is not required, so the
-    // retry is a plain navigation and paymentProceedHandler must not run.
-    expect(props.authenticate).not.toHaveBeenCalled();
-  });
-
-  it("should go back to status without bailing out on plan upgrade", async () => {
-    props = createTestProps({
-      params: {status: "failed"},
-      settings: {subscriptions: true, mobile_phone_verification: true},
-      userData: {
-        ...responseData,
-        method: "mobile_phone",
-        is_verified: true,
-        in_upgrade: true,
-        payment_url: "https://payment.example.com/pay/1",
-      },
-    });
-    validateToken.mockReturnValue(true);
-    cancelUpgradePlan.mockResolvedValue({
-      in_upgrade: false,
-      payment_url: null,
-    });
-    wrapper = shallow(<PaymentStatus {...props} />, {
-      context: loadingContextValue,
-    });
-    await tick();
-    wrapper.find(".payment-status-row-4 .button").simulate("click", {});
-    await tick();
-    expect(cancelUpgradePlan).toHaveBeenCalledWith(
-      props.orgSlug,
-      props.userData.auth_token || props.userData.key,
-      props.language,
-    );
-    expect(props.setUserData).toHaveBeenCalledWith({
-      ...props.userData,
-      in_upgrade: false,
-      proceedToPayment: false,
-      payment_url: null,
-      mustLogin: undefined,
-      mustLogout: true,
-      captivePortalLogoutOnly: true,
-    });
-    expect(props.navigate).toHaveBeenCalledWith("/default/status");
-    expect(props.logout).not.toHaveBeenCalled();
   });
 
   it("should clear in_upgrade even when the cancel response omits it", async () => {
@@ -657,12 +530,104 @@ describe("Test <PaymentStatus /> cases", () => {
     await tick();
     wrapper.find(".payment-status-row-4 .button").simulate("click", {});
     await tick();
+    expect(cancelUpgradePlan).toHaveBeenCalledWith(
+      props.orgSlug,
+      props.userData.auth_token || props.userData.key,
+      props.language,
+    );
+    expect(props.setUserData).toHaveBeenCalledWith({
+      ...props.userData,
+      in_upgrade: false,
+      proceedToPayment: false,
+      payment_url: null,
+      mustLogin: undefined,
+      mustLogout: true,
+      captivePortalLogoutOnly: true,
+    });
+    expect(props.navigate).toHaveBeenCalledWith("/default/status");
+    expect(props.logout).not.toHaveBeenCalled();
     // Stale flag must be cleared, otherwise a later status reload could
     // wrongly force the user back into the payment flow.
     expect(mockCookiesRemove).toHaveBeenCalledWith("default_proceedToPayment", {
       path: "/",
     });
     expect(localStorage.getItem("default_proceedToPayment")).toBeNull();
+  });
+
+  it("should silently ignore a 404 when cancelling an non-existent upgrade", async () => {
+    const spyToastError = jest.spyOn(toast, "error");
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    cancelUpgradePlan.mockRejectedValue({response: {status: 404}});
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    wrapper.find(".payment-status-row-4 .button").simulate("click", {});
+    await tick();
+    // The order does not existing on OpenWISP
+    expect(spyToastError).not.toHaveBeenCalled();
+    expect(logError).not.toHaveBeenCalled();
+    expect(props.setUserData).toHaveBeenCalledWith({
+      ...props.userData,
+      in_upgrade: false,
+      proceedToPayment: false,
+      payment_url: null,
+      mustLogin: undefined,
+      mustLogout: true,
+      captivePortalLogoutOnly: true,
+    });
+    expect(props.navigate).toHaveBeenCalledWith("/default/status");
+  });
+
+  it("should report an error and still go back to status when cancelling fails unexpectedly", async () => {
+    const spyToastError = jest.spyOn(toast, "error");
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    cancelUpgradePlan.mockRejectedValue({response: {status: 500}});
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    wrapper.find(".payment-status-row-4 .button").simulate("click", {});
+    await tick();
+    expect(spyToastError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(
+      {response: {status: 500}},
+      "Error while cancelling plan upgrade",
+    );
+    // The user must still be able to leave the failed page even if the
+    // cancel request itself errored out.
+    expect(props.setUserData).toHaveBeenCalledWith({
+      ...props.userData,
+      in_upgrade: false,
+      proceedToPayment: false,
+      payment_url: null,
+      mustLogin: undefined,
+      mustLogout: true,
+      captivePortalLogoutOnly: true,
+    });
+    expect(props.navigate).toHaveBeenCalledWith("/default/status");
   });
 
   it("should hide the continue button if the payment url is not available", async () => {
@@ -835,9 +800,13 @@ describe("Test <PaymentStatus /> cases", () => {
     });
   });
 
-  it("should render the draft page for a plan upgrade", async () => {
+  it("should not set mustLogin on draft arrival for an upgrade not requiring internet", async () => {
     props = createTestProps({
-      settings: {subscriptions: true, mobile_phone_verification: true},
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: false,
+      },
       userData: {
         ...responseData,
         method: "mobile_phone",
@@ -858,53 +827,6 @@ describe("Test <PaymentStatus /> cases", () => {
       .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
       .first();
     expect(payProcButton.length).toEqual(1);
-  });
-
-  it("should set mustLogin on draft arrival for a plan upgrade requiring internet", async () => {
-    props = createTestProps({
-      settings: {
-        subscriptions: true,
-        mobile_phone_verification: true,
-        payment_requires_internet: true,
-      },
-      userData: {
-        ...responseData,
-        method: "mobile_phone",
-        is_verified: true,
-        in_upgrade: true,
-      },
-      params: {status: "draft"},
-    });
-    validateToken.mockReturnValue(true);
-    wrapper = shallow(<PaymentStatus {...props} />, {
-      context: loadingContextValue,
-    });
-    await tick();
-    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
-      expect.objectContaining({mustLogin: true}),
-    );
-  });
-
-  it("should not set mustLogin on draft arrival for an upgrade not requiring internet", async () => {
-    props = createTestProps({
-      settings: {
-        subscriptions: true,
-        mobile_phone_verification: true,
-        payment_requires_internet: false,
-      },
-      userData: {
-        ...responseData,
-        method: "mobile_phone",
-        is_verified: true,
-        in_upgrade: true,
-      },
-      params: {status: "draft"},
-    });
-    validateToken.mockReturnValue(true);
-    wrapper = shallow(<PaymentStatus {...props} />, {
-      context: loadingContextValue,
-    });
-    await tick();
     expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
       expect.objectContaining({mustLogin: undefined}),
     );

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -129,6 +129,24 @@ describe("Test <PaymentStatus /> cases", () => {
     expect(wrapper.find(".payment-status-row-1").length).toEqual(0);
   });
 
+  it("should show a loader instead of the wrong abandon button on a cold draft load", () => {
+    // Cold reload: in_upgrade unknown until validateToken resolves, so
+    // isDraftUpgrade cannot be decided yet. Rendering renderDraft early would
+    // briefly wire the abandon button to logout instead of backToStatus.
+    props = createTestProps({
+      userData: {},
+      params: {status: "draft"},
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    expect(wrapper.find(Loader)).toHaveLength(1);
+    expect(wrapper.find("Navigate").length).toEqual(0);
+    expect(wrapper.find(".main-column.single").length).toEqual(0);
+    expect(wrapper.find("button.button.full").length).toEqual(0);
+  });
+
   it("should call logout correctly when clicking on logout button", async () => {
     const spyToast = jest.spyOn(toast, "success");
     props = createTestProps({
@@ -263,6 +281,8 @@ describe("Test <PaymentStatus /> cases", () => {
     wrapper = shallow(<PaymentStatus {...props} />, {
       context: loadingContextValue,
     });
+    await tick();
+    wrapper.instance().props.setUserData.mockClear();
     let payProcButton = wrapper
       .find("Link.button.full")
       .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
@@ -282,6 +302,7 @@ describe("Test <PaymentStatus /> cases", () => {
     wrapper = shallow(<PaymentStatus {...props} />, {
       context: loadingContextValue,
     });
+    await tick();
     payProcButton = wrapper
       .find("Link.button.full")
       .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
@@ -317,6 +338,7 @@ describe("Test <PaymentStatus /> cases", () => {
     wrapper = shallow(<PaymentStatus {...props} />, {
       context: loadingContextValue,
     });
+    await tick();
     const payProcButton = wrapper
       .find("Link.button.full")
       .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
@@ -325,7 +347,7 @@ describe("Test <PaymentStatus /> cases", () => {
     // Verify the cookie was set
     expect(mockCookiesSet).toHaveBeenCalledWith(
       "default_proceedToPayment",
-      "true",
+      true,
       {path: "/", maxAge: 60},
     );
     // Verify userData was updated with proceedToPayment
@@ -463,7 +485,7 @@ describe("Test <PaymentStatus /> cases", () => {
     });
     expect(mockCookiesSet).toHaveBeenCalledWith(
       "default_proceedToPayment",
-      "true",
+      true,
       {path: "/", maxAge: 60},
     );
     expect(props.authenticate).toHaveBeenCalledWith(true);
@@ -494,6 +516,7 @@ describe("Test <PaymentStatus /> cases", () => {
       ...props.userData,
       in_upgrade: false,
       proceedToPayment: false,
+      payment_url: null,
       mustLogin: undefined,
       mustLogout: true,
       captivePortalLogoutOnly: true,
@@ -587,6 +610,39 @@ describe("Test <PaymentStatus /> cases", () => {
       mustLogout: true,
       captivePortalLogoutOnly: true,
     });
+    expect(props.navigate).toHaveBeenCalledWith("/default/status");
+  });
+
+  it("should surface a 404 that carries response_code NOT_FOUND", async () => {
+    // Our own server also answers 404 for an unknown organization slug, in
+    // that shape. That must not be swallowed as "nothing to cancel".
+    const spyToastError = jest.spyOn(toast, "error");
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    cancelUpgradePlan.mockRejectedValue({
+      response: {status: 404, data: {response_code: "NOT_FOUND"}},
+    });
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    wrapper.find(".payment-status-row-4 .button").simulate("click", {});
+    await tick();
+    expect(spyToastError).toHaveBeenCalledTimes(1);
+    expect(logError).toHaveBeenCalledWith(
+      {response: {status: 404, data: {response_code: "NOT_FOUND"}}},
+      "Error while cancelling plan upgrade",
+    );
     expect(props.navigate).toHaveBeenCalledWith("/default/status");
   });
 

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -550,7 +550,9 @@ describe("Test <PaymentStatus /> cases", () => {
     wrapper.find(".payment-status-row-3 .button").at(0).simulate("click");
     expect(mockCookiesSet).not.toHaveBeenCalled();
     expect(wrapper.instance().props.setUserData).not.toHaveBeenCalled();
-    expect(props.authenticate).toHaveBeenCalledWith(true);
+    // No captive portal login needed when internet is not required, so the
+    // retry is a plain navigation and paymentProceedHandler must not run.
+    expect(props.authenticate).not.toHaveBeenCalled();
   });
 
   it("should go back to status without bailing out on plan upgrade", async () => {
@@ -592,6 +594,37 @@ describe("Test <PaymentStatus /> cases", () => {
     });
     expect(props.navigate).toHaveBeenCalledWith("/default/status");
     expect(props.logout).not.toHaveBeenCalled();
+  });
+
+  it("should clear in_upgrade even when the cancel response omits it", async () => {
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    // The cancel API response does not echo back in_upgrade.
+    cancelUpgradePlan.mockResolvedValue({});
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    wrapper.find(".payment-status-row-4 .button").simulate("click", {});
+    await tick();
+    expect(props.setUserData).toHaveBeenCalledWith({
+      ...props.userData,
+      in_upgrade: false,
+      proceedToPayment: false,
+      mustLogin: undefined,
+      mustLogout: true,
+      captivePortalLogoutOnly: true,
+    });
   });
 
   it("should clear the persisted proceedToPayment flag when abandoning an upgrade", async () => {

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -13,11 +13,13 @@ import Loader from "../../utils/loader";
 import tick from "../../utils/tick";
 import validateToken from "../../utils/validate-token";
 import loadTranslation from "../../utils/load-translation";
+import cancelUpgradePlan from "../../utils/cancel-upgrade-plan";
 
 jest.mock("axios");
 jest.mock("../../utils/get-config");
 jest.mock("../../utils/validate-token");
 jest.mock("../../utils/load-translation");
+jest.mock("../../utils/cancel-upgrade-plan");
 
 const defaultConfig = getConfig("default", true);
 const createTestProps = (props) => ({
@@ -360,11 +362,28 @@ describe("Test <PaymentStatus /> cases", () => {
       },
     });
     validateToken.mockReturnValue(true);
+    cancelUpgradePlan.mockResolvedValue({
+      in_upgrade: false,
+      payment_url: null,
+    });
     wrapper = shallow(<PaymentStatus {...props} />, {
       context: loadingContextValue,
     });
     await tick();
     wrapper.find(".payment-status-row-4 .button").simulate("click", {});
+    await tick();
+    expect(cancelUpgradePlan).toHaveBeenCalledWith(
+      props.orgSlug,
+      props.userData.auth_token || props.userData.key,
+      props.language,
+    );
+    expect(props.setUserData).toHaveBeenCalledWith({
+      ...props.userData,
+      in_upgrade: false,
+      proceedToPayment: false,
+      payment_url: null,
+      mustLogin: undefined,
+    });
     expect(props.navigate).toHaveBeenCalledWith("/default/status");
     expect(props.logout).not.toHaveBeenCalled();
   });
@@ -382,6 +401,10 @@ describe("Test <PaymentStatus /> cases", () => {
       },
     });
     validateToken.mockReturnValue(true);
+    cancelUpgradePlan.mockResolvedValue({
+      in_upgrade: false,
+      payment_url: null,
+    });
     wrapper = shallow(<PaymentStatus {...props} />, {
       context: loadingContextValue,
     });
@@ -613,7 +636,11 @@ describe("Test <PaymentStatus /> cases", () => {
 
   it("should go back to status without logout from the upgrade draft page", async () => {
     props = createTestProps({
-      settings: {subscriptions: true, mobile_phone_verification: true},
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: true,
+      },
       userData: {
         ...responseData,
         method: "mobile_phone",
@@ -628,8 +655,29 @@ describe("Test <PaymentStatus /> cases", () => {
       context: loadingContextValue,
     });
     await tick();
+    // componentDidMount sets mustLogin so /status performs the
+    // captive-portal login once the user proceeds with the payment
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({mustLogin: true}),
+    );
     // the second button is the "go back" action for an upgrader
     wrapper.find(".button").at(1).simulate("click", {});
+    await tick();
+    expect(cancelUpgradePlan).toHaveBeenCalledWith(
+      props.orgSlug,
+      props.userData.auth_token || props.userData.key,
+      props.language,
+    );
+    // giving up must clear the stale upgrade/login flags, not just navigate,
+    // otherwise /status bounces the user straight back to /payment/draft
+    expect(props.setUserData).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        in_upgrade: false,
+        proceedToPayment: false,
+        payment_url: null,
+        mustLogin: undefined,
+      }),
+    );
     expect(props.navigate).toHaveBeenCalledWith(`/${props.orgSlug}/status`);
     expect(props.logout).not.toHaveBeenCalled();
   });

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -534,4 +534,103 @@ describe("Test <PaymentStatus /> cases", () => {
       mustLogin: true,
     });
   });
+
+  it("should render the draft page for a plan upgrade", async () => {
+    props = createTestProps({
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+      params: {status: "draft"},
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    // the upgrader must not be bounced off the draft page
+    expect(wrapper.find("Navigate").length).toEqual(0);
+    const payProcButton = wrapper
+      .find("Link.button.full")
+      .findWhere((node) => node.text() === t`PAY_PROC_BTN`)
+      .first();
+    expect(payProcButton.length).toEqual(1);
+  });
+
+  it("should set mustLogin on draft arrival for a plan upgrade requiring internet", async () => {
+    props = createTestProps({
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: true,
+      },
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+      },
+      params: {status: "draft"},
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({mustLogin: true}),
+    );
+  });
+
+  it("should not set mustLogin on draft arrival for an upgrade not requiring internet", async () => {
+    props = createTestProps({
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: false,
+      },
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+      },
+      params: {status: "draft"},
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({mustLogin: undefined}),
+    );
+  });
+
+  it("should go back to status without logout from the upgrade draft page", async () => {
+    props = createTestProps({
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+      params: {status: "draft"},
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    // the second button is the "go back" action for an upgrader
+    wrapper.find(".button").at(1).simulate("click", {});
+    expect(props.navigate).toHaveBeenCalledWith(`/${props.orgSlug}/status`);
+    expect(props.logout).not.toHaveBeenCalled();
+  });
 });

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -283,6 +283,7 @@ describe("Test <PaymentStatus /> cases", () => {
     expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith({
       ...responseData,
       is_verified: false,
+      mustLogin: true,
       proceedToPayment: true,
     });
   });
@@ -452,6 +453,104 @@ describe("Test <PaymentStatus /> cases", () => {
     expect(
       wrapper.find(".payment-status-row-3 .button").at(0).props().to,
     ).toEqual("/default/payment/process");
+  });
+
+  it("should route failed-upgrade retry through /status when payment requires internet", async () => {
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: true,
+      },
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    expect(
+      wrapper.find(".payment-status-row-3 .button").at(0).props().to,
+    ).toEqual("/default/status");
+  });
+
+  it("should log into the captive portal when retrying a failed upgrade", async () => {
+    const mockCookiesSet = jest.fn();
+    props = createTestProps({
+      params: {status: "failed"},
+      captivePortalSyncAuth: true,
+      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: true,
+      },
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    wrapper.find(".payment-status-row-3 .button").at(0).simulate("click");
+    expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({mustLogin: true, proceedToPayment: true}),
+    );
+    expect(mockCookiesSet).toHaveBeenCalledWith("default_mustLogin", true, {
+      path: "/",
+      maxAge: 60,
+    });
+    expect(mockCookiesSet).toHaveBeenCalledWith(
+      "default_proceedToPayment",
+      "true",
+      {path: "/", maxAge: 60},
+    );
+    expect(props.authenticate).toHaveBeenCalledWith(true);
+  });
+
+  it("should not force captive portal login when retrying and payment does not require internet", async () => {
+    const mockCookiesSet = jest.fn();
+    props = createTestProps({
+      params: {status: "failed"},
+      cookies: {set: mockCookiesSet, get: jest.fn(), remove: jest.fn()},
+      settings: {
+        subscriptions: true,
+        mobile_phone_verification: true,
+        payment_requires_internet: false,
+      },
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    expect(
+      wrapper.find(".payment-status-row-3 .button").at(0).props().to,
+    ).toEqual("/default/payment/process");
+    wrapper.find(".payment-status-row-3 .button").at(0).simulate("click");
+    expect(mockCookiesSet).not.toHaveBeenCalled();
+    expect(wrapper.instance().props.setUserData).not.toHaveBeenCalled();
+    expect(props.authenticate).toHaveBeenCalledWith(true);
   });
 
   it("should go back to status without bailing out on plan upgrade", async () => {

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -300,6 +300,93 @@ describe("Test <PaymentStatus /> cases", () => {
     expect(spyToast.mock.calls.length).toBe(0);
   });
 
+  it("should render failed state when a plan upgrade payment fails", async () => {
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    expect(wrapper.find("Navigate").length).toEqual(0);
+    expect(wrapper.find(".payment-status-row-1").length).toEqual(1);
+    expect(
+      wrapper.find(".payment-status-row-3 .button").at(0).props().to,
+    ).toEqual("/default/payment/process");
+  });
+
+  it("should go back to status without bailing out on plan upgrade", async () => {
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: "https://payment.example.com/pay/1",
+      },
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    wrapper.find(".payment-status-row-4 .button").simulate("click", {});
+    expect(props.navigate).toHaveBeenCalledWith("/default/status");
+    expect(props.logout).not.toHaveBeenCalled();
+  });
+
+  it("should hide the continue button if the payment url is not available", async () => {
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+        in_upgrade: true,
+        payment_url: null,
+      },
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    expect(wrapper.find("Navigate").length).toEqual(0);
+    expect(wrapper.find(".payment-status-row-3").length).toEqual(0);
+    expect(wrapper.find(".payment-status-row-4 .button").length).toEqual(1);
+  });
+
+  it("should redirect to status if verified and not upgrading", async () => {
+    props = createTestProps({
+      params: {status: "failed"},
+      settings: {subscriptions: true, mobile_phone_verification: true},
+      userData: {
+        ...responseData,
+        method: "mobile_phone",
+        is_verified: true,
+      },
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    await tick();
+    expect(wrapper.find("Navigate").length).toEqual(1);
+    expect(wrapper.find("Navigate").props().to).toEqual("/default/status");
+  });
+
   it("should redirect to login if not authenticated", async () => {
     const spyToast = jest.spyOn(toast, "success");
     props = createTestProps({

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -59,9 +59,7 @@ describe("<PaymentStatus /> rendering with placeholder translation tags", () => 
   it("should render translation placeholder correctly", () => {
     const renderer = new ShallowRenderer();
     renderer.render(<PaymentStatus {...props} />);
-    // ShallowRenderer does not run componentDidMount, so isTokenValid stays
-    // at its initial null; move it to a resolved value to exercise the
-    // actual failed-page markup instead of the cold-load loader guard
+    // ShallowRenderer skips componentDidMount; advance isTokenValid past null for markup
     renderer.getMountedInstance().setState({isTokenValid: true});
     const wrapper = renderer.getRenderOutput();
     expect(wrapper).toMatchSnapshot();
@@ -115,9 +113,7 @@ describe("Test <PaymentStatus /> cases", () => {
   });
 
   it("should show a loader instead of the wrong failed variant on cold load", () => {
-    // simulates a fresh reload landing on /payment/failed before
-    // validateToken() has resolved and repopulated userData: in_upgrade is
-    // not known yet, so neither failed variant should paint
+    // Cold reload: in_upgrade unknown until validateToken resolves, show loader
     props = createTestProps({
       userData: {},
       params: {status: "failed"},
@@ -406,6 +402,7 @@ describe("Test <PaymentStatus /> cases", () => {
       payment_url: null,
       mustLogin: undefined,
       mustLogout: true,
+      captivePortalLogoutOnly: true,
     });
     expect(props.navigate).toHaveBeenCalledWith("/default/status");
     expect(props.logout).not.toHaveBeenCalled();
@@ -598,7 +595,6 @@ describe("Test <PaymentStatus /> cases", () => {
       context: loadingContextValue,
     });
     await tick();
-    // the upgrader must not be bounced off the draft page
     expect(wrapper.find("Navigate").length).toEqual(0);
     const payProcButton = wrapper
       .find("Link.button.full")
@@ -678,12 +674,10 @@ describe("Test <PaymentStatus /> cases", () => {
       context: loadingContextValue,
     });
     await tick();
-    // componentDidMount sets mustLogin so /status performs the
-    // captive-portal login once the user proceeds with the payment
+    // componentDidMount sets mustLogin so /status performs captive-portal login on proceed
     expect(props.setUserData).toHaveBeenCalledWith(
       expect.objectContaining({mustLogin: true}),
     );
-    // the second button is the "go back" action for an upgrader
     wrapper.find(".button").at(1).simulate("click", {});
     await tick();
     expect(cancelUpgradePlan).toHaveBeenCalledWith(
@@ -691,8 +685,7 @@ describe("Test <PaymentStatus /> cases", () => {
       props.userData.auth_token || props.userData.key,
       props.language,
     );
-    // giving up must clear the stale upgrade/login flags, not just navigate,
-    // otherwise /status bounces the user straight back to /payment/draft
+    // Clear stale flags to prevent /status redirecting back to /payment/draft
     expect(props.setUserData).toHaveBeenLastCalledWith(
       expect.objectContaining({
         in_upgrade: false,
@@ -700,11 +693,11 @@ describe("Test <PaymentStatus /> cases", () => {
         payment_url: null,
         mustLogin: undefined,
         mustLogout: true,
+        captivePortalLogoutOnly: true,
       }),
     );
     expect(props.navigate).toHaveBeenCalledWith(`/${props.orgSlug}/status`);
-    // the app-level (WLP) session must stay intact; only the captive
-    // portal session is torn down via the mustLogout flag above
+    // Keep WLP session intact; only tear down captive portal session
     expect(props.logout).not.toHaveBeenCalled();
   });
 });

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -405,6 +405,7 @@ describe("Test <PaymentStatus /> cases", () => {
       proceedToPayment: false,
       payment_url: null,
       mustLogin: undefined,
+      mustLogout: true,
     });
     expect(props.navigate).toHaveBeenCalledWith("/default/status");
     expect(props.logout).not.toHaveBeenCalled();
@@ -656,7 +657,7 @@ describe("Test <PaymentStatus /> cases", () => {
     );
   });
 
-  it("should go back to status without logout from the upgrade draft page", async () => {
+  it("should log out of captive portal (not of the app) when going back from the upgrade draft page", async () => {
     props = createTestProps({
       settings: {
         subscriptions: true,
@@ -698,9 +699,12 @@ describe("Test <PaymentStatus /> cases", () => {
         proceedToPayment: false,
         payment_url: null,
         mustLogin: undefined,
+        mustLogout: true,
       }),
     );
     expect(props.navigate).toHaveBeenCalledWith(`/${props.orgSlug}/status`);
+    // the app-level (WLP) session must stay intact; only the captive
+    // portal session is torn down via the mustLogout flag above
     expect(props.logout).not.toHaveBeenCalled();
   });
 });

--- a/client/components/payment-status/payment-status.test.js
+++ b/client/components/payment-status/payment-status.test.js
@@ -9,6 +9,7 @@ import {t} from "ttag";
 import {loadingContextValue} from "../../utils/loading-context";
 import getConfig from "../../utils/get-config";
 import PaymentStatus from "./payment-status";
+import Loader from "../../utils/loader";
 import tick from "../../utils/tick";
 import validateToken from "../../utils/validate-token";
 import loadTranslation from "../../utils/load-translation";
@@ -55,7 +56,12 @@ describe("<PaymentStatus /> rendering with placeholder translation tags", () => 
   });
   it("should render translation placeholder correctly", () => {
     const renderer = new ShallowRenderer();
-    const wrapper = renderer.render(<PaymentStatus {...props} />);
+    renderer.render(<PaymentStatus {...props} />);
+    // ShallowRenderer does not run componentDidMount, so isTokenValid stays
+    // at its initial null; move it to a resolved value to exercise the
+    // actual failed-page markup instead of the cold-load loader guard
+    renderer.getMountedInstance().setState({isTokenValid: true});
+    const wrapper = renderer.getRenderOutput();
     expect(wrapper).toMatchSnapshot();
   });
 });
@@ -104,6 +110,23 @@ describe("Test <PaymentStatus /> cases", () => {
     ).toEqual("/default/payment/draft");
     expect(wrapper.find(".payment-status-row-4 .button").length).toEqual(1);
     expect(wrapper.find("Navigate").length).toEqual(0);
+  });
+
+  it("should show a loader instead of the wrong failed variant on cold load", () => {
+    // simulates a fresh reload landing on /payment/failed before
+    // validateToken() has resolved and repopulated userData: in_upgrade is
+    // not known yet, so neither failed variant should paint
+    props = createTestProps({
+      userData: {},
+      params: {status: "failed"},
+    });
+    validateToken.mockReturnValue(true);
+    wrapper = shallow(<PaymentStatus {...props} />, {
+      context: loadingContextValue,
+    });
+    expect(wrapper.find(Loader)).toHaveLength(1);
+    expect(wrapper.find("Navigate").length).toEqual(0);
+    expect(wrapper.find(".payment-status-row-1").length).toEqual(0);
   });
 
   it("should call logout correctly when clicking on logout button", async () => {

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -37,6 +37,11 @@ import handleSession from "../../utils/session";
 import getPlanSelection from "../../utils/get-plan-selection";
 import getPlans from "../../utils/get-plans";
 import upgradePlan from "../../utils/upgrade-plan";
+import {
+  storeValue,
+  resolveStoredValue,
+  clearStoredValue,
+} from "../../utils/synced-storage";
 
 export default class Status extends React.Component {
   constructor(props) {
@@ -154,14 +159,15 @@ export default class Status extends React.Component {
         mustLogout: userMustLogout,
         captivePortalLogoutOnly: userCaptivePortalLogoutOnly,
         repeatLogin,
+        proceedToPayment: userProceedToPayment,
       } = userData;
-      const mustLogin = this.resolveStoredValue(
+      const mustLogin = resolveStoredValue(
         captivePortalSyncAuth,
         `${orgSlug}_mustLogin`,
         userMustLogin,
         cookies,
       );
-      const mustLogout = this.resolveStoredValue(
+      const mustLogout = resolveStoredValue(
         captivePortalSyncAuth,
         `${orgSlug}_mustLogout`,
         userMustLogout,
@@ -169,14 +175,34 @@ export default class Status extends React.Component {
       );
       // Captive-portal-only logout: tear down RADIUS session, keep WLP session intact
       this.captivePortalLogoutOnly = Boolean(
-        this.resolveStoredValue(
+        resolveStoredValue(
           captivePortalSyncAuth,
           `${orgSlug}_captivePortalLogoutOnly`,
           userCaptivePortalLogoutOnly,
           cookies,
         ),
       );
+      // Restore proceedToPayment flag that may have been lost during
+      // the page reload caused by synchronous captive portal auth.
+      const proceedToPayment = resolveStoredValue(
+        captivePortalSyncAuth,
+        `${orgSlug}_proceedToPayment`,
+        userProceedToPayment,
+        cookies,
+      );
       ({userData} = this.props);
+      // Apply the persisted proceedToPayment flag to userData if it
+      // was restored from cookie/localStorage after a page reload.
+      if (
+        proceedToPayment !== undefined &&
+        proceedToPayment !== userData.proceedToPayment
+      ) {
+        setUserData({
+          ...userData,
+          proceedToPayment,
+        });
+        ({userData} = this.props);
+      }
       if (userData.password_expired === true) {
         toast.warning(t`PASSWORD_EXPIRED`);
         setUserData({
@@ -238,7 +264,7 @@ export default class Status extends React.Component {
         shouldLogin = shouldLogin && settings.payment_requires_internet;
       }
       if (this.loginFormRef && this.loginFormRef.current && shouldLogin) {
-        this.storeValue(
+        storeValue(
           captivePortalSyncAuth,
           `${orgSlug}_mustLogin`,
           false,
@@ -302,6 +328,7 @@ export default class Status extends React.Component {
       setUserData,
       statusPage,
       internetMode,
+      cookies,
     } = this.props;
     const {setLoading} = this.context;
     // if the user needs bank card verification,
@@ -314,6 +341,8 @@ export default class Status extends React.Component {
           ...userData,
           proceedToPayment: false,
         });
+        // Clear persisted proceedToPayment flag
+        clearStoredValue(`${orgSlug}_proceedToPayment`, cookies);
         navigate(`/${orgSlug}/payment/process`);
         return;
       }
@@ -524,7 +553,7 @@ export default class Status extends React.Component {
           radius_user_token: undefined,
         });
         // Portal login needed to reach payment gateway (unrelated to CoA)
-        this.storeValue(
+        storeValue(
           captivePortalSyncAuth,
           `${orgSlug}_mustLogin`,
           true,
@@ -618,14 +647,14 @@ export default class Status extends React.Component {
           this.repeatLogin = true;
         }
         if (!internetMode) {
-          this.storeValue(
+          storeValue(
             captivePortalSyncAuth,
             `${orgSlug}_mustLogout`,
             true,
             cookies,
           );
           if (this.captivePortalLogoutOnly) {
-            this.storeValue(
+            storeValue(
               captivePortalSyncAuth,
               `${orgSlug}_captivePortalLogoutOnly`,
               true,
@@ -748,7 +777,7 @@ export default class Status extends React.Component {
     const userAutoLogin = localStorage.getItem("userAutoLogin") === "true";
     if (
       loggedOut ||
-      this.resolveStoredValue(
+      resolveStoredValue(
         captivePortalSyncAuth,
         `${orgSlug}_mustLogout`,
         false,
@@ -757,7 +786,7 @@ export default class Status extends React.Component {
     ) {
       const captivePortalLogoutOnly =
         this.captivePortalLogoutOnly ||
-        this.resolveStoredValue(
+        resolveStoredValue(
           captivePortalSyncAuth,
           `${orgSlug}_captivePortalLogoutOnly`,
           false,
@@ -871,60 +900,6 @@ export default class Status extends React.Component {
         // Unknown message type, do nothing
         break;
     }
-  };
-
-  // eslint-disable-next-line class-methods-use-this
-  storeValue = (captivePortalSyncAuth, key, value, cookies) => {
-    /**
-     * Stores a value in both cookies and localStorage if synchronous
-     * captive portal authentication is enabled.
-     *
-     * In synchronous authentication, submitting the captive portal form
-     * triggers a page reload, which resets the component state.
-     * Storing the value in cookies ensures it persists across reloads.
-     *
-     * The value is also saved in localStorage as a fallback in case the browser does not support cookies.
-     *
-     * @param {boolean} captivePortalSyncAuth - Whether synchronous authentication is enabled.
-     * @param {string} key - The key under which the value is stored.
-     * @param {boolean} value - The value to store.
-     * @param {Cookies} cookies - The cookies instance used to set the cookie.
-     */
-    if (!captivePortalSyncAuth) {
-      return;
-    }
-    localStorage.setItem(key, value);
-    cookies.set(key, value, {path: "/", maxAge: 60});
-  };
-
-  // eslint-disable-next-line class-methods-use-this
-  resolveStoredValue = (captivePortalSyncAuth, key, fallback, cookies) => {
-    /**
-     * Resolves the correct value by checking cookies, then localStorage,
-     * falling back to a default value if neither is found.
-     *
-     * @param {boolean} captivePortalSyncAuth - Whether synchronization is enabled.
-     * @param {string} cookieKey - The key to look for in cookies and localStorage.
-     * @param {*} fallback - The fallback value if no valid stored value is found.
-     * @returns {*} - The selected value based on storage or fallback.
-     */
-    if (!captivePortalSyncAuth) {
-      return fallback;
-    }
-
-    const cookieValue = cookies.get(key);
-    if (cookieValue !== undefined) {
-      localStorage.removeItem(key);
-      return cookieValue;
-    }
-
-    const localStorageValue = localStorage.getItem(key);
-    if (localStorageValue !== null) {
-      localStorage.removeItem(key);
-      return localStorageValue === "true";
-    }
-
-    return fallback;
   };
 
   updateScreenWidth = () => {

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -22,6 +22,7 @@ import {
 } from "../../constants";
 import LoadingContext from "../../utils/loading-context";
 import getText from "../../utils/get-text";
+import getErrorText from "../../utils/get-error-text";
 import logError from "../../utils/log-error";
 import Contact from "../contact-box";
 import shouldLinkBeShown from "../../utils/should-link-be-shown";
@@ -485,17 +486,16 @@ export default class Status extends React.Component {
           payment_url: response.payment_url,
           in_upgrade: response.in_upgrade,
         });
-        // After a successful payment, the user is redirected back to the status page.
-        // When the captive portal supports CoA, the backend restores access
-        // transparently, so no forced re-login is needed here.
-        if (!settings.captive_portal_supports_coa) {
-          this.storeValue(
-            captivePortalSyncAuth,
-            `${orgSlug}_mustLogin`,
-            true,
-            cookies,
-          );
-        }
+        // The user must be logged into the captive portal (under a
+        // temporary/limited group if their previous plan was exhausted) so
+        // they can reach the payment gateway. This is unrelated to CoA
+        // support: CoA only affects what happens after payment succeeds.
+        this.storeValue(
+          captivePortalSyncAuth,
+          `${orgSlug}_mustLogin`,
+          true,
+          cookies,
+        );
         // When the payment gateway requires internet access, the user must first
         // be logged into the captive portal. Send them to the draft payment page
         // (which warns about the limited payment window) and route the "proceed"
@@ -508,7 +508,8 @@ export default class Status extends React.Component {
         }
       })
       .catch((error) => {
-        toast.error(t`ERR_OCCUR`);
+        const errorText = getErrorText(error, t`ERR_OCCUR`);
+        toast.error(errorText);
         logError(error, "Error while upgrading plan");
       });
   }

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -831,6 +831,7 @@ export default class Status extends React.Component {
       orgSlug,
       setInternetMode,
       setPlanExhausted,
+      userData,
     } = this.props;
     const {setLoading} = this.context;
     const {message, type, warningMessage, showUpgradeBtn, planExhausted} =
@@ -871,7 +872,12 @@ export default class Status extends React.Component {
             if (planExhausted !== false) {
               setPlanExhausted(true);
             }
-            setLoading(false);
+            // When redirected to /status solely to complete captive portal
+            // login before payment, keep the loader on so the status page
+            // contents stay hidden while finalOperations() navigates away.
+            if (!userData.proceedToPayment) {
+              setLoading(false);
+            }
           },
         );
         break;

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -270,7 +270,7 @@ export default class Status extends React.Component {
     const {setLoading} = this.context;
     // if the user needs bank card verification,
     // redirect to payment page and stop here
-    if (needsVerify("bank_card", userData, settings)) {
+    if (needsVerify("bank_card", userData, settings) || userData.in_upgrade) {
       // avoid redirect loop from proceed to payment
       if (settings.payment_requires_internet && userData.proceedToPayment) {
         // reset proceedToPayment
@@ -465,6 +465,7 @@ export default class Status extends React.Component {
       navigate,
       setUserData,
       captivePortalSyncAuth,
+      settings,
     } = this.props;
     const auth_token = cookies.get(`${orgSlug}_auth_token`);
     const {upgradePlans} = this.state;
@@ -493,7 +494,16 @@ export default class Status extends React.Component {
           true,
           cookies,
         );
-        navigate(`/${orgSlug}/payment/process`);
+        // When the payment gateway requires internet access, the user must first
+        // be logged into the captive portal. Send them to the draft payment page
+        // (which warns about the limited payment window) and route the "proceed"
+        // action through /status for the captive portal login, mirroring the
+        // bank_card draft flow. Otherwise go straight to the payment gateway.
+        if (settings.payment_requires_internet) {
+          navigate(`/${orgSlug}/payment/draft`);
+        } else {
+          navigate(`/${orgSlug}/payment/process`);
+        }
       })
       .catch((error) => {
         toast.error(t`ERR_OCCUR`);

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -469,7 +469,7 @@ export default class Status extends React.Component {
     const auth_token = cookies.get(`${orgSlug}_auth_token`);
     const {upgradePlans} = this.state;
     handleSession(orgSlug, auth_token, cookies);
-    upgradePlan(
+    return upgradePlan(
       orgSlug,
       upgradePlans[event.target.value].id,
       userData.auth_token,

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -486,14 +486,16 @@ export default class Status extends React.Component {
           in_upgrade: response.in_upgrade,
         });
         // After a successful payment, the user is redirected back to the status page.
-        // If the user plan was previously exhausted, they need to be logged into the captive portal
-        // to regain internet access. This ensures seamless browsing after upgrading their plan.
-        this.storeValue(
-          captivePortalSyncAuth,
-          `${orgSlug}_mustLogin`,
-          true,
-          cookies,
-        );
+        // When the captive portal supports CoA, the backend restores access
+        // transparently, so no forced re-login is needed here.
+        if (!settings.captive_portal_supports_coa) {
+          this.storeValue(
+            captivePortalSyncAuth,
+            `${orgSlug}_mustLogin`,
+            true,
+            cookies,
+          );
+        }
         // When the payment gateway requires internet access, the user must first
         // be logged into the captive portal. Send them to the draft payment page
         // (which warns about the limited payment window) and route the "proceed"
@@ -1548,6 +1550,7 @@ Status.propTypes = {
     mobile_phone_verification: PropTypes.bool,
     subscriptions: PropTypes.bool,
     payment_requires_internet: PropTypes.bool,
+    captive_portal_supports_coa: PropTypes.bool,
   }).isRequired,
   setUserData: PropTypes.func.isRequired,
   setInternetMode: PropTypes.func.isRequired,

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -482,6 +482,7 @@ export default class Status extends React.Component {
         setUserData({
           ...userData,
           payment_url: response.payment_url,
+          in_upgrade: response.in_upgrade,
         });
         // After a successful payment, the user is redirected back to the status page.
         // If the user plan was previously exhausted, they need to be logged into the captive portal

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -833,7 +833,8 @@ export default class Status extends React.Component {
       setPlanExhausted,
     } = this.props;
     const {setLoading} = this.context;
-    const {message, type, warningMessage, showUpgradeBtn} = event.data;
+    const {message, type, warningMessage, showUpgradeBtn, planExhausted} =
+      event.data;
 
     // Only accept messages from trusted origins,
     // For more info read: https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#security_concern
@@ -864,8 +865,12 @@ export default class Status extends React.Component {
             ...(showUpgradeBtn !== undefined && {showUpgradeBtn}),
           },
           () => {
-            // Change the message on the status page to reflect plan exhaustion
-            setPlanExhausted(true);
+            // Only set planExhausted if the captive portal explicitly
+            // indicates plan exhaustion. For backward compatibility,
+            // default to true when the flag is not provided.
+            if (planExhausted !== false) {
+              setPlanExhausted(true);
+            }
             setLoading(false);
           },
         );

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -485,6 +485,13 @@ export default class Status extends React.Component {
           ...userData,
           payment_url: response.payment_url,
           in_upgrade: response.in_upgrade,
+          // The radius_user_token the user already has was consumed by
+          // their earlier captive portal login, so it must be cleared here.
+          // Otherwise validateToken() would skip refetching it (it only
+          // refetches when radius_user_token is undefined) and the
+          // mustLogin re-login below would replay the same stale, already
+          // consumed token, silently failing to authenticate the user.
+          radius_user_token: undefined,
         });
         // The user must be logged into the captive portal (under a
         // temporary/limited group if their previous plan was exhausted) so

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -333,7 +333,10 @@ export default class Status extends React.Component {
     const {setLoading} = this.context;
     // if the user needs bank card verification,
     // redirect to payment page and stop here
-    if (needsVerify("bank_card", userData, settings) || userData.in_upgrade) {
+    if (
+      needsVerify("bank_card", userData, settings) ||
+      (userData.in_upgrade && userData.payment_url)
+    ) {
       // avoid redirect loop from proceed to payment
       if (settings.payment_requires_internet && userData.proceedToPayment) {
         // reset proceedToPayment
@@ -529,7 +532,6 @@ export default class Status extends React.Component {
       userData,
       navigate,
       setUserData,
-      captivePortalSyncAuth,
       settings,
     } = this.props;
     const auth_token = cookies.get(`${orgSlug}_auth_token`);
@@ -552,13 +554,6 @@ export default class Status extends React.Component {
           // Token consumed by portal login; clear so validateToken refetches one
           radius_user_token: undefined,
         });
-        // Portal login needed to reach payment gateway (unrelated to CoA)
-        storeValue(
-          captivePortalSyncAuth,
-          `${orgSlug}_mustLogin`,
-          true,
-          cookies,
-        );
         // Route through draft page to enforce portal login before gateway
         if (settings.payment_requires_internet) {
           navigate(`/${orgSlug}/payment/draft`);
@@ -634,35 +629,37 @@ export default class Status extends React.Component {
     } = this.props;
     const macaddr = cookies.get(`${orgSlug}_macaddr`);
     const params = {calling_station_id: macaddr};
-    localStorage.setItem("userAutoLogin", String(userAutoLogin));
+    if (!this.captivePortalLogoutOnly) {
+      localStorage.setItem("userAutoLogin", String(userAutoLogin));
+    }
     setLoading(true);
     await this.getUserActiveRadiusSessions(params);
     const {sessionsToLogout} = this.state;
 
-    if (sessionsToLogout.length > 0) {
+    // In internet mode there is no captive portal session to tear down, so
+    // skip the logout form and settle the page directly below.
+    if (sessionsToLogout.length > 0 && !internetMode) {
       if (this.logoutFormRef && this.logoutFormRef.current) {
         if (!repeatLogin) {
           this.setStateSafe({loggedOut: true});
         } else {
           this.repeatLogin = true;
         }
-        if (!internetMode) {
+        storeValue(
+          captivePortalSyncAuth,
+          `${orgSlug}_mustLogout`,
+          true,
+          cookies,
+        );
+        if (this.captivePortalLogoutOnly) {
           storeValue(
             captivePortalSyncAuth,
-            `${orgSlug}_mustLogout`,
+            `${orgSlug}_captivePortalLogoutOnly`,
             true,
             cookies,
           );
-          if (this.captivePortalLogoutOnly) {
-            storeValue(
-              captivePortalSyncAuth,
-              `${orgSlug}_captivePortalLogoutOnly`,
-              true,
-              cookies,
-            );
-          }
-          this.logoutFormRef.current.submit();
         }
+        this.logoutFormRef.current.submit();
         return;
       }
     }
@@ -1582,7 +1579,6 @@ Status.propTypes = {
     mobile_phone_verification: PropTypes.bool,
     subscriptions: PropTypes.bool,
     payment_requires_internet: PropTypes.bool,
-    captive_portal_supports_coa: PropTypes.bool,
   }).isRequired,
   setUserData: PropTypes.func.isRequired,
   setInternetMode: PropTypes.func.isRequired,

--- a/client/components/status/status.js
+++ b/client/components/status/status.js
@@ -69,6 +69,7 @@ export default class Status extends React.Component {
       showUpgradeBtn: true,
     };
     this.repeatLogin = false;
+    this.captivePortalLogoutOnly = false;
     this.isComponentMounted = true;
     this.getUserRadiusSessions = this.getUserRadiusSessions.bind(this);
     this.getUserRadiusUsage = this.getUserRadiusUsage.bind(this);
@@ -151,6 +152,7 @@ export default class Status extends React.Component {
       const {
         mustLogin: userMustLogin,
         mustLogout: userMustLogout,
+        captivePortalLogoutOnly: userCaptivePortalLogoutOnly,
         repeatLogin,
       } = userData;
       const mustLogin = this.resolveStoredValue(
@@ -164,6 +166,15 @@ export default class Status extends React.Component {
         `${orgSlug}_mustLogout`,
         userMustLogout,
         cookies,
+      );
+      // Captive-portal-only logout: tear down RADIUS session, keep WLP session intact
+      this.captivePortalLogoutOnly = Boolean(
+        this.resolveStoredValue(
+          captivePortalSyncAuth,
+          `${orgSlug}_captivePortalLogoutOnly`,
+          userCaptivePortalLogoutOnly,
+          cookies,
+        ),
       );
       ({userData} = this.props);
       if (userData.password_expired === true) {
@@ -257,6 +268,30 @@ export default class Status extends React.Component {
     window.removeEventListener("resize", this.updateScreenWidth);
     window.removeEventListener("message", this.handlePostMessage);
   }
+
+  // After captive-portal-only logout: skip redux logout and userData reset to preserve WLP session
+  finishCaptivePortalLogoutOnly = () => {
+    const {orgSlug, cookies, setUserData, userData} = this.props;
+    const {setLoading} = this.context;
+    [
+      `${orgSlug}_mustLogin`,
+      `${orgSlug}_mustLogout`,
+      `${orgSlug}_captivePortalLogoutOnly`,
+    ].forEach((key) => {
+      cookies.remove(key, {path: "/"});
+      localStorage.removeItem(key);
+    });
+    this.captivePortalLogoutOnly = false;
+    this.setStateSafe({loggedOut: false});
+    setUserData({
+      ...userData,
+      mustLogin: undefined,
+      mustLogout: undefined,
+      captivePortalLogoutOnly: undefined,
+    });
+    setLoading(false);
+    this.finalOperations();
+  };
 
   async finalOperations() {
     const {
@@ -485,29 +520,17 @@ export default class Status extends React.Component {
           ...userData,
           payment_url: response.payment_url,
           in_upgrade: response.in_upgrade,
-          // The radius_user_token the user already has was consumed by
-          // their earlier captive portal login, so it must be cleared here.
-          // Otherwise validateToken() would skip refetching it (it only
-          // refetches when radius_user_token is undefined) and the
-          // mustLogin re-login below would replay the same stale, already
-          // consumed token, silently failing to authenticate the user.
+          // Token consumed by portal login; clear so validateToken refetches one
           radius_user_token: undefined,
         });
-        // The user must be logged into the captive portal (under a
-        // temporary/limited group if their previous plan was exhausted) so
-        // they can reach the payment gateway. This is unrelated to CoA
-        // support: CoA only affects what happens after payment succeeds.
+        // Portal login needed to reach payment gateway (unrelated to CoA)
         this.storeValue(
           captivePortalSyncAuth,
           `${orgSlug}_mustLogin`,
           true,
           cookies,
         );
-        // When the payment gateway requires internet access, the user must first
-        // be logged into the captive portal. Send them to the draft payment page
-        // (which warns about the limited payment window) and route the "proceed"
-        // action through /status for the captive portal login, mirroring the
-        // bank_card draft flow. Otherwise go straight to the payment gateway.
+        // Route through draft page to enforce portal login before gateway
         if (settings.payment_requires_internet) {
           navigate(`/${orgSlug}/payment/draft`);
         } else {
@@ -601,6 +624,14 @@ export default class Status extends React.Component {
             true,
             cookies,
           );
+          if (this.captivePortalLogoutOnly) {
+            this.storeValue(
+              captivePortalSyncAuth,
+              `${orgSlug}_captivePortalLogoutOnly`,
+              true,
+              cookies,
+            );
+          }
           this.logoutFormRef.current.submit();
         }
         return;
@@ -608,6 +639,11 @@ export default class Status extends React.Component {
     }
 
     if (repeatLogin) {
+      return;
+    }
+    // No active portal session; settle page directly for captive-portal-only logout
+    if (this.captivePortalLogoutOnly) {
+      this.finishCaptivePortalLogoutOnly();
       return;
     }
     setUserData(initialState.userData);
@@ -719,6 +755,19 @@ export default class Status extends React.Component {
         cookies,
       )
     ) {
+      const captivePortalLogoutOnly =
+        this.captivePortalLogoutOnly ||
+        this.resolveStoredValue(
+          captivePortalSyncAuth,
+          `${orgSlug}_captivePortalLogoutOnly`,
+          false,
+          cookies,
+        );
+      // Portal session already torn down; keep WLP session for captive-portal-only logout
+      if (captivePortalLogoutOnly) {
+        this.finishCaptivePortalLogoutOnly();
+        return;
+      }
       logout(cookies, orgSlug, userAutoLogin);
       toast.success(t`LOGOUT_SUCCESS`);
 

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1441,6 +1441,35 @@ describe("<Status /> interactions", () => {
     );
   });
 
+  it("should not redirect to payment/draft after an upgrade was abandoned via backToStatus", async () => {
+    validateToken.mockReturnValue(true);
+    jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");
+    jest.spyOn(Status.prototype, "getUserPastRadiusSessions");
+    props = createTestProps();
+    // reflects the userData left behind by PaymentStatus.backToStatus()
+    // after the user gives up on a plan upgrade
+    props.userData = {
+      ...responseData,
+      in_upgrade: false,
+      proceedToPayment: false,
+      payment_url: null,
+      mustLogin: undefined,
+    };
+    props.settings.subscriptions = true;
+    props.settings.payment_requires_internet = true;
+    const setLoading = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading},
+    });
+    await tick();
+    expect(props.navigate).not.toHaveBeenCalledWith(
+      `/${props.orgSlug}/payment/draft`,
+    );
+    expect(props.navigate).not.toHaveBeenCalledWith(
+      `/${props.orgSlug}/payment/process`,
+    );
+  });
+
   it("should logout if mustLogout is true", async () => {
     validateToken.mockReturnValue(true);
     jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -2407,6 +2407,30 @@ describe("<Status /> interactions", () => {
     await tick();
     expect(toast.error.mock.calls.length).toBe(1);
   });
+  it("test upgradeUserPlan relays the backend error message on 429 (too many orders)", async () => {
+    jest.spyOn(toast, "error");
+    axios.mockImplementation(() =>
+      Promise.reject({
+        response: {
+          status: 429,
+          statusText: "TOO_MANY_REQUESTS",
+          data: {
+            detail: "You have reached the maximum number of allowed orders.",
+          },
+        },
+      }),
+    );
+    props = createTestProps();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.setState({upgradePlans: [{id: "1"}]});
+    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
+    expect(toast.error).toHaveBeenCalledWith(
+      "You have reached the maximum number of allowed orders.",
+    );
+  });
   it("test upgradeUserPlan stores in_upgrade", async () => {
     axios.mockImplementation(() =>
       Promise.resolve({
@@ -2491,7 +2515,10 @@ describe("<Status /> interactions", () => {
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/draft");
     expect(props.navigate).not.toHaveBeenCalledWith("/default/payment/process");
   });
-  it("test upgradeUserPlan does not force mustLogin when captive portal supports CoA", async () => {
+  it("test upgradeUserPlan forces mustLogin when captive portal supports CoA", async () => {
+    // the initial captive portal login is needed to reach the payment
+    // gateway regardless of CoA support: CoA only affects what happens
+    // after payment succeeds, not this initial login
     axios.mockImplementation(() =>
       Promise.resolve({
         status: 200,
@@ -2518,9 +2545,7 @@ describe("<Status /> interactions", () => {
         in_upgrade: true,
       }),
     );
-    // the backend restores access transparently via CoA, so the frontend
-    // must not force a captive portal re-login
-    expect(localStorage.getItem("default_mustLogin")).toBe(null);
+    expect(localStorage.getItem("default_mustLogin")).toBe("true");
   });
   it("should hide limit-info element if getUserRadiusUsage fails", async () => {
     validateToken.mockReturnValue(true);

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1407,11 +1407,9 @@ describe("<Status /> interactions", () => {
     wrapper.instance().loginIframeRef.current = {};
     wrapper.instance().loginFormRef.current = mockRef;
     wrapper.instance().handleLoginIframe();
-    // ensure the user is forwarded to the payment gateway
     expect(props.navigate).toHaveBeenCalledWith(
       `/${props.orgSlug}/payment/process`,
     );
-    // ensure proceedToPayment is reset
     expect(props.setUserData).toHaveBeenCalledWith({
       ...props.userData,
       proceedToPayment: false,
@@ -1435,7 +1433,6 @@ describe("<Status /> interactions", () => {
       context: {setLoading},
     });
     await tick();
-    // a normal /status visit by an upgrader must not be redirected
     expect(props.navigate).not.toHaveBeenCalledWith(
       `/${props.orgSlug}/payment/process`,
     );
@@ -1446,8 +1443,7 @@ describe("<Status /> interactions", () => {
     jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");
     jest.spyOn(Status.prototype, "getUserPastRadiusSessions");
     props = createTestProps();
-    // reflects the userData left behind by PaymentStatus.backToStatus()
-    // after the user gives up on a plan upgrade
+    // Simulate userData after PaymentStatus.backToStatus() cleanup
     props.userData = {
       ...responseData,
       in_upgrade: false,
@@ -1516,6 +1512,63 @@ describe("<Status /> interactions", () => {
     expect(Status.prototype.getUserActiveRadiusSessions.mock.calls.length).toBe(
       1,
     );
+  });
+
+  it("should log out of captive portal only and keep the app session when captivePortalLogoutOnly is true", async () => {
+    validateToken.mockReturnValue(true);
+    jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");
+    axios.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        data: [
+          {
+            session_id: 1,
+            start_time: "2020-09-08T00:22:28-04:00",
+            stop_time: "2020-09-08T00:22:29-04:00",
+            input_octets: 100000,
+            output_octets: 100000,
+          },
+        ],
+        headers: {},
+      }),
+    );
+    const spyToast = jest.spyOn(toast, "success");
+    props = createTestProps({
+      userData: {
+        ...responseData,
+        mustLogout: true,
+        captivePortalLogoutOnly: true,
+      },
+    });
+    const setLoading = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading},
+      disableLifecycleMethods: true,
+    });
+    const status = wrapper.instance();
+    const mockRef = {submit: jest.fn()};
+    const {setUserData} = status.props;
+    status.logoutFormRef = {current: mockRef};
+    status.logoutIframeRef = {current: {}};
+    status.componentDidMount();
+    await tick();
+    status.handleLogoutIframe();
+    await tick();
+    // Captive portal session torn down but WLP session preserved
+    expect(mockRef.submit).toHaveBeenCalledTimes(1);
+    expect(status.props.logout).not.toHaveBeenCalled();
+    expect(setUserData).not.toHaveBeenCalledWith(initialState.userData);
+    // Transient flags cleared; userData preserved for authentication
+    expect(setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mustLogin: undefined,
+        mustLogout: undefined,
+        captivePortalLogoutOnly: undefined,
+      }),
+    );
+    expect(status.state.loggedOut).toBe(false);
+    expect(spyToast).not.toHaveBeenCalled();
   });
 
   it("should logout if activeSession do not contain current MAC", async () => {
@@ -2510,15 +2563,12 @@ describe("<Status /> interactions", () => {
         in_upgrade: true,
       }),
     );
-    // the captive portal login must happen before the payment gateway,
-    // so the user is sent to the draft page, not straight to the gateway
+    // Route through draft to enforce portal login before gateway payment
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/draft");
     expect(props.navigate).not.toHaveBeenCalledWith("/default/payment/process");
   });
   it("test upgradeUserPlan forces mustLogin when captive portal supports CoA", async () => {
-    // the initial captive portal login is needed to reach the payment
-    // gateway regardless of CoA support: CoA only affects what happens
-    // after payment succeeds, not this initial login
+    // Portal login needed regardless of CoA support (CoA only applies post-payment)
     axios.mockImplementation(() =>
       Promise.resolve({
         status: 200,

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1387,6 +1387,60 @@ describe("<Status /> interactions", () => {
     });
   });
 
+  it("should redirect an upgrader to /payment/process after captive portal login", async () => {
+    validateToken.mockReturnValue(true);
+    props = createTestProps();
+    props.userData = {
+      ...responseData,
+      payment_url: "https://account.openwisp.io/payment/123",
+      in_upgrade: true,
+      mustLogin: true,
+      proceedToPayment: true,
+    };
+    props.settings.subscriptions = true;
+    props.settings.payment_requires_internet = true;
+    const setLoading = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading},
+    });
+    const mockRef = {submit: jest.fn()};
+    wrapper.instance().loginIframeRef.current = {};
+    wrapper.instance().loginFormRef.current = mockRef;
+    wrapper.instance().handleLoginIframe();
+    // ensure the user is forwarded to the payment gateway
+    expect(props.navigate).toHaveBeenCalledWith(
+      `/${props.orgSlug}/payment/process`,
+    );
+    // ensure proceedToPayment is reset
+    expect(props.setUserData).toHaveBeenCalledWith({
+      ...props.userData,
+      proceedToPayment: false,
+    });
+  });
+
+  it("should not forward an upgrader to payment when proceedToPayment is false", async () => {
+    validateToken.mockReturnValue(true);
+    jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");
+    jest.spyOn(Status.prototype, "getUserPastRadiusSessions");
+    props = createTestProps();
+    props.userData = {
+      ...responseData,
+      in_upgrade: true,
+      proceedToPayment: false,
+    };
+    props.settings.subscriptions = true;
+    props.settings.payment_requires_internet = true;
+    const setLoading = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading},
+    });
+    await tick();
+    // a normal /status visit by an upgrader must not be redirected
+    expect(props.navigate).not.toHaveBeenCalledWith(
+      `/${props.orgSlug}/payment/process`,
+    );
+  });
+
   it("should logout if mustLogout is true", async () => {
     validateToken.mockReturnValue(true);
     jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");
@@ -2336,6 +2390,7 @@ describe("<Status /> interactions", () => {
       }),
     );
     props = createTestProps();
+    props.settings.payment_requires_internet = false;
     wrapper = shallow(<Status {...props} />, {
       context: {setLoading: jest.fn()},
       disableLifecycleMethods: true,
@@ -2362,6 +2417,7 @@ describe("<Status /> interactions", () => {
       }),
     );
     props = createTestProps();
+    props.settings.payment_requires_internet = false;
     wrapper = shallow(<Status {...props} />, {
       context: {setLoading: jest.fn()},
       disableLifecycleMethods: true,
@@ -2375,6 +2431,36 @@ describe("<Status /> interactions", () => {
       }),
     );
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/process");
+  });
+  it("test upgradeUserPlan redirects to draft when payment_requires_internet", async () => {
+    axios.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        data: {
+          payment_url: "https://payment.example.com/pay/1",
+          in_upgrade: true,
+        },
+      }),
+    );
+    props = createTestProps();
+    props.settings.payment_requires_internet = true;
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.setState({upgradePlans: [{id: "1"}]});
+    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_url: "https://payment.example.com/pay/1",
+        in_upgrade: true,
+      }),
+    );
+    // the captive portal login must happen before the payment gateway,
+    // so the user is sent to the draft page, not straight to the gateway
+    expect(props.navigate).toHaveBeenCalledWith("/default/payment/draft");
+    expect(props.navigate).not.toHaveBeenCalledWith("/default/payment/process");
   });
   it("should hide limit-info element if getUserRadiusUsage fails", async () => {
     validateToken.mockReturnValue(true);
@@ -2729,7 +2815,7 @@ describe("<Status /> interactions", () => {
     toast.success.mock.calls.pop()[1].onOpen();
     expect(toast.dismiss).toHaveBeenCalledWith("main_toast_id");
     expect(prop.navigate).toHaveBeenCalledWith(
-      `/${prop.orgSlug}/payment/process`,
+      `/${prop.orgSlug}/payment/draft`,
     );
     expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith({
       ...prop.userData,
@@ -2850,7 +2936,7 @@ describe("<Status /> interactions", () => {
     toast.success.mock.calls.pop()[1].onOpen();
     expect(toast.dismiss).toHaveBeenCalledWith("main_toast_id");
     expect(prop.navigate).toHaveBeenCalledWith(
-      `/${prop.orgSlug}/payment/process`,
+      `/${prop.orgSlug}/payment/draft`,
     );
     expect(wrapper.instance().props.setUserData).toHaveBeenCalledWith({
       ...prop.userData,

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -706,6 +706,25 @@ describe("<Status /> interactions", () => {
     expect(setLoadingMock).toHaveBeenLastCalledWith(false);
   });
 
+  it("authMessage keeps loader on during payment login redirect", async () => {
+    props = createTestProps({userData: {proceedToPayment: true}});
+    const setLoadingMock = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: setLoadingMock},
+      disableLifecycleMethods: true,
+    });
+    jest.spyOn(toast, "info");
+    const status = wrapper.instance();
+    status.handlePostMessage({
+      data: {message: "RADIUS Info", type: "authMessage"},
+      origin: "http://localhost",
+    });
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(props.setPlanExhausted).toHaveBeenCalledTimes(1);
+    expect(setLoadingMock).toHaveBeenCalledTimes(1);
+    expect(setLoadingMock).toHaveBeenLastCalledWith(true);
+  });
+
   it("test handlePostMessage internet-mode", async () => {
     props = createTestProps();
     const setLoadingMock = jest.fn();

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -2491,6 +2491,37 @@ describe("<Status /> interactions", () => {
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/draft");
     expect(props.navigate).not.toHaveBeenCalledWith("/default/payment/process");
   });
+  it("test upgradeUserPlan does not force mustLogin when captive portal supports CoA", async () => {
+    axios.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        data: {
+          payment_url: "https://payment.example.com/pay/1",
+          in_upgrade: true,
+        },
+      }),
+    );
+    localStorage.clear();
+    props = createTestProps();
+    props.captivePortalSyncAuth = true;
+    props.settings.captive_portal_supports_coa = true;
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.setState({upgradePlans: [{id: "1"}]});
+    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_url: "https://payment.example.com/pay/1",
+        in_upgrade: true,
+      }),
+    );
+    // the backend restores access transparently via CoA, so the frontend
+    // must not force a captive portal re-login
+    expect(localStorage.getItem("default_mustLogin")).toBe(null);
+  });
   it("should hide limit-info element if getUserRadiusUsage fails", async () => {
     validateToken.mockReturnValue(true);
     axios.mockImplementation(() =>

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -2547,6 +2547,31 @@ describe("<Status /> interactions", () => {
     );
     expect(localStorage.getItem("default_mustLogin")).toBe("true");
   });
+  it("test upgradeUserPlan resets radius_user_token so a fresh one is fetched", async () => {
+    axios.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        data: {
+          payment_url: "https://payment.example.com/pay/1",
+          in_upgrade: true,
+        },
+      }),
+    );
+    props = createTestProps();
+    props.settings.payment_requires_internet = false;
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.setState({upgradePlans: [{id: "1"}]});
+    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        radius_user_token: undefined,
+      }),
+    );
+  });
   it("should hide limit-info element if getUserRadiusUsage fails", async () => {
     validateToken.mockReturnValue(true);
     axios.mockImplementation(() =>

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1466,6 +1466,67 @@ describe("<Status /> interactions", () => {
     );
   });
 
+  it("should restore proceedToPayment from cookie after a sync-auth page reload", async () => {
+    // Synchronous captive portal auth reloads the page on login, wiping the
+    // in-memory proceedToPayment flag. It must be restored from the cookie
+    // that was persisted before the reload, otherwise the user is not
+    // forwarded to /payment/process (see PaymentStatus.paymentProceedHandler).
+    validateToken.mockReturnValue(true);
+    const cookies = new Cookies();
+    cookies.set("default_proceedToPayment", "true", {path: "/", maxAge: 60});
+    props = createTestProps({
+      captivePortalSyncAuth: true,
+      location: {search: ""},
+      cookies,
+      userData: {
+        ...responseData,
+        in_upgrade: true,
+        mustLogin: false,
+      },
+    });
+    props.settings.payment_requires_internet = true;
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+    });
+    await tick();
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({proceedToPayment: true}),
+    );
+  });
+
+  it("should clear the persisted proceedToPayment flag after redirecting to payment/process", async () => {
+    validateToken.mockReturnValue(true);
+    props = createTestProps();
+    const cookies = new Cookies();
+    cookies.set("default_proceedToPayment", "true", {path: "/", maxAge: 60});
+    localStorage.setItem("default_proceedToPayment", "true");
+    props.cookies = cookies;
+    props.userData = {
+      ...responseData,
+      is_verified: false,
+      method: "bank_card",
+      payment_url: "https://account.openwisp.io/payment/123",
+      mustLogin: true,
+      proceedToPayment: true,
+    };
+    props.settings.subscriptions = true;
+    props.settings.payment_requires_internet = true;
+    const setLoading = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading},
+    });
+    const mockRef = {submit: jest.fn()};
+    wrapper.instance().loginIframeRef.current = {};
+    wrapper.instance().loginFormRef.current = mockRef;
+    wrapper.instance().handleLoginIframe();
+    expect(props.navigate).toHaveBeenCalledWith(
+      `/${props.orgSlug}/payment/process`,
+    );
+    // Stale flag must be cleared to prevent a redirect loop on the next visit
+    expect(cookies.get("default_proceedToPayment")).toBeUndefined();
+    expect(localStorage.getItem("default_proceedToPayment")).toBeNull();
+  });
+
   it("should logout if mustLogout is true", async () => {
     validateToken.mockReturnValue(true);
     jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -2341,12 +2341,37 @@ describe("<Status /> interactions", () => {
       disableLifecycleMethods: true,
     });
     wrapper.setState({upgradePlans: [{id: "1"}]});
-    wrapper.instance().upgradeUserPlan({target: {value: 0}});
-    await tick();
+    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
     expect(props.setUserData).toHaveBeenCalledWith(
       expect.objectContaining({
         payment_url: "https://payment.example.com/pay/1",
         in_upgrade: true,
+      }),
+    );
+    expect(props.navigate).toHaveBeenCalledWith("/default/payment/process");
+  });
+  it("test upgradeUserPlan stores in_upgrade false", async () => {
+    axios.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        data: {
+          payment_url: "https://payment.example.com/pay/1",
+          in_upgrade: false,
+        },
+      }),
+    );
+    props = createTestProps();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.setState({upgradePlans: [{id: "1"}]});
+    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_url: "https://payment.example.com/pay/1",
+        in_upgrade: false,
       }),
     );
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/process");

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1366,6 +1366,13 @@ describe("<Status /> interactions", () => {
     };
     props.settings.subscriptions = true;
     props.settings.payment_requires_internet = true;
+    // Seed a persisted proceedToPayment flag to verify it gets cleared
+    // once the redirect to /payment/process happens.
+    props.cookies.set("default_proceedToPayment", "true", {
+      path: "/",
+      maxAge: 60,
+    });
+    localStorage.setItem("default_proceedToPayment", "true");
     const setLoading = jest.fn();
     wrapper = shallow(<Status {...props} />, {
       context: {setLoading},
@@ -1385,6 +1392,9 @@ describe("<Status /> interactions", () => {
       ...props.userData,
       proceedToPayment: false,
     });
+    // Stale flag must be cleared to prevent a redirect loop on the next visit
+    expect(props.cookies.get("default_proceedToPayment")).toBeUndefined();
+    expect(localStorage.getItem("default_proceedToPayment")).toBeNull();
   });
 
   it("should redirect an upgrader to /payment/process after captive portal login", async () => {
@@ -1416,7 +1426,7 @@ describe("<Status /> interactions", () => {
     });
   });
 
-  it("should not forward an upgrader to payment when proceedToPayment is false", async () => {
+  it("should send an upgrader to the draft page when proceedToPayment is false", async () => {
     validateToken.mockReturnValue(true);
     jest.spyOn(Status.prototype, "getUserActiveRadiusSessions");
     jest.spyOn(Status.prototype, "getUserPastRadiusSessions");
@@ -1433,6 +1443,11 @@ describe("<Status /> interactions", () => {
       context: {setLoading},
     });
     await tick();
+    // in_upgrade without proceedToPayment routes through the draft page,
+    // not straight to the payment gateway.
+    expect(props.navigate).toHaveBeenCalledWith(
+      `/${props.orgSlug}/payment/draft`,
+    );
     expect(props.navigate).not.toHaveBeenCalledWith(
       `/${props.orgSlug}/payment/process`,
     );
@@ -1492,39 +1507,6 @@ describe("<Status /> interactions", () => {
     expect(props.setUserData).toHaveBeenCalledWith(
       expect.objectContaining({proceedToPayment: true}),
     );
-  });
-
-  it("should clear the persisted proceedToPayment flag after redirecting to payment/process", async () => {
-    validateToken.mockReturnValue(true);
-    props = createTestProps();
-    const cookies = new Cookies();
-    cookies.set("default_proceedToPayment", "true", {path: "/", maxAge: 60});
-    localStorage.setItem("default_proceedToPayment", "true");
-    props.cookies = cookies;
-    props.userData = {
-      ...responseData,
-      is_verified: false,
-      method: "bank_card",
-      payment_url: "https://account.openwisp.io/payment/123",
-      mustLogin: true,
-      proceedToPayment: true,
-    };
-    props.settings.subscriptions = true;
-    props.settings.payment_requires_internet = true;
-    const setLoading = jest.fn();
-    wrapper = shallow(<Status {...props} />, {
-      context: {setLoading},
-    });
-    const mockRef = {submit: jest.fn()};
-    wrapper.instance().loginIframeRef.current = {};
-    wrapper.instance().loginFormRef.current = mockRef;
-    wrapper.instance().handleLoginIframe();
-    expect(props.navigate).toHaveBeenCalledWith(
-      `/${props.orgSlug}/payment/process`,
-    );
-    // Stale flag must be cleared to prevent a redirect loop on the next visit
-    expect(cookies.get("default_proceedToPayment")).toBeUndefined();
-    expect(localStorage.getItem("default_proceedToPayment")).toBeNull();
   });
 
   it("should logout if mustLogout is true", async () => {
@@ -2545,8 +2527,15 @@ describe("<Status /> interactions", () => {
       "You have reached the maximum number of allowed orders.",
     );
   });
-  it("test upgradeUserPlan stores in_upgrade", async () => {
-    axios.mockImplementation(() =>
+  it("test upgradeUserPlan stores in_upgrade from the response", async () => {
+    props = createTestProps();
+    props.settings.payment_requires_internet = false;
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.setState({upgradePlans: [{id: "1"}]});
+    axios.mockImplementationOnce(() =>
       Promise.resolve({
         status: 200,
         statusText: "OK",
@@ -2556,24 +2545,19 @@ describe("<Status /> interactions", () => {
         },
       }),
     );
-    props = createTestProps();
-    props.settings.payment_requires_internet = false;
-    wrapper = shallow(<Status {...props} />, {
-      context: {setLoading: jest.fn()},
-      disableLifecycleMethods: true,
-    });
-    wrapper.setState({upgradePlans: [{id: "1"}]});
     await wrapper.instance().upgradeUserPlan({target: {value: 0}});
     expect(props.setUserData).toHaveBeenCalledWith(
       expect.objectContaining({
         payment_url: "https://payment.example.com/pay/1",
         in_upgrade: true,
+        // Token consumed by portal login; must be cleared so a fresh one is fetched
+        radius_user_token: undefined,
       }),
     );
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/process");
-  });
-  it("test upgradeUserPlan stores in_upgrade false", async () => {
-    axios.mockImplementation(() =>
+
+    // A falsy in_upgrade must survive the assignment untouched
+    axios.mockImplementationOnce(() =>
       Promise.resolve({
         status: 200,
         statusText: "OK",
@@ -2583,23 +2567,13 @@ describe("<Status /> interactions", () => {
         },
       }),
     );
-    props = createTestProps();
-    props.settings.payment_requires_internet = false;
-    wrapper = shallow(<Status {...props} />, {
-      context: {setLoading: jest.fn()},
-      disableLifecycleMethods: true,
-    });
-    wrapper.setState({upgradePlans: [{id: "1"}]});
     await wrapper.instance().upgradeUserPlan({target: {value: 0}});
     expect(props.setUserData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payment_url: "https://payment.example.com/pay/1",
-        in_upgrade: false,
-      }),
+      expect.objectContaining({in_upgrade: false}),
     );
-    expect(props.navigate).toHaveBeenCalledWith("/default/payment/process");
   });
-  it("test upgradeUserPlan redirects to draft when payment_requires_internet", async () => {
+  it("test upgradeUserPlan redirects to draft and persists mustLogin when payment_requires_internet", async () => {
+    // Portal login needed regardless of CoA support (CoA only applies post-payment)
     axios.mockImplementation(() =>
       Promise.resolve({
         status: 200,
@@ -2610,8 +2584,11 @@ describe("<Status /> interactions", () => {
         },
       }),
     );
+    localStorage.clear();
     props = createTestProps();
     props.settings.payment_requires_internet = true;
+    props.captivePortalSyncAuth = true;
+    props.settings.captive_portal_supports_coa = true;
     wrapper = shallow(<Status {...props} />, {
       context: {setLoading: jest.fn()},
       disableLifecycleMethods: true,
@@ -2627,61 +2604,7 @@ describe("<Status /> interactions", () => {
     // Route through draft to enforce portal login before gateway payment
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/draft");
     expect(props.navigate).not.toHaveBeenCalledWith("/default/payment/process");
-  });
-  it("test upgradeUserPlan forces mustLogin when captive portal supports CoA", async () => {
-    // Portal login needed regardless of CoA support (CoA only applies post-payment)
-    axios.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        statusText: "OK",
-        data: {
-          payment_url: "https://payment.example.com/pay/1",
-          in_upgrade: true,
-        },
-      }),
-    );
-    localStorage.clear();
-    props = createTestProps();
-    props.captivePortalSyncAuth = true;
-    props.settings.captive_portal_supports_coa = true;
-    wrapper = shallow(<Status {...props} />, {
-      context: {setLoading: jest.fn()},
-      disableLifecycleMethods: true,
-    });
-    wrapper.setState({upgradePlans: [{id: "1"}]});
-    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
-    expect(props.setUserData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        payment_url: "https://payment.example.com/pay/1",
-        in_upgrade: true,
-      }),
-    );
     expect(localStorage.getItem("default_mustLogin")).toBe("true");
-  });
-  it("test upgradeUserPlan resets radius_user_token so a fresh one is fetched", async () => {
-    axios.mockImplementation(() =>
-      Promise.resolve({
-        status: 200,
-        statusText: "OK",
-        data: {
-          payment_url: "https://payment.example.com/pay/1",
-          in_upgrade: true,
-        },
-      }),
-    );
-    props = createTestProps();
-    props.settings.payment_requires_internet = false;
-    wrapper = shallow(<Status {...props} />, {
-      context: {setLoading: jest.fn()},
-      disableLifecycleMethods: true,
-    });
-    wrapper.setState({upgradePlans: [{id: "1"}]});
-    await wrapper.instance().upgradeUserPlan({target: {value: 0}});
-    expect(props.setUserData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        radius_user_token: undefined,
-      }),
-    );
   });
   it("should hide limit-info element if getUserRadiusUsage fails", async () => {
     validateToken.mockReturnValue(true);

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -1435,6 +1435,7 @@ describe("<Status /> interactions", () => {
       ...responseData,
       in_upgrade: true,
       proceedToPayment: false,
+      payment_url: "https://payment.example.com/pay/1",
     };
     props.settings.subscriptions = true;
     props.settings.payment_requires_internet = true;
@@ -2103,6 +2104,46 @@ describe("<Status /> interactions", () => {
     await tick();
     expect(mockRef.submit).toHaveBeenCalledTimes(1);
   });
+  it("should complete the logout instead of hanging when there are open sessions in internetMode", async () => {
+    const setLoading = jest.fn();
+    const session = {start_time: "2021-07-08T00:22:28-04:00", stop_time: null};
+    const spyToastSuccess = jest.spyOn(toast, "success");
+    props = createTestProps({internetMode: true});
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading},
+      disableLifecycleMethods: true,
+    });
+    wrapper
+      .instance()
+      .setState({sessionsToLogout: [session], activeSession: [session]});
+    await wrapper.instance().handleLogout(false);
+    expect(props.setUserData).toHaveBeenCalledWith(initialState.userData);
+    expect(props.logout).toHaveBeenCalledWith(
+      props.cookies,
+      props.orgSlug,
+      false,
+    );
+    expect(setLoading).toHaveBeenCalledWith(false);
+    expect(spyToastSuccess).toHaveBeenCalled();
+  });
+  it("should not overwrite userAutoLogin during a captive-portal-only logout", async () => {
+    // captivePortalLogoutOnly keeps the WLP session alive, so the flag that
+    // controls auto-login on the next WLP visit must not be touched by it.
+    localStorage.removeItem("userAutoLogin");
+    const setLoading = jest.fn();
+    props = createTestProps();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading},
+      disableLifecycleMethods: true,
+    });
+    wrapper.instance().captivePortalLogoutOnly = true;
+    await wrapper.instance().handleLogout(true);
+    expect(localStorage.getItem("userAutoLogin")).toBeNull();
+    // The captive-portal-only settle path must still run to completion.
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({captivePortalLogoutOnly: undefined}),
+    );
+  });
   it("should not display STATUS_CONTENT and radius usage when logged in internetMode", async () => {
     const prop = createTestProps({
       internetMode: true,
@@ -2572,8 +2613,7 @@ describe("<Status /> interactions", () => {
       expect.objectContaining({in_upgrade: false}),
     );
   });
-  it("test upgradeUserPlan redirects to draft and persists mustLogin when payment_requires_internet", async () => {
-    // Portal login needed regardless of CoA support (CoA only applies post-payment)
+  it("test upgradeUserPlan redirects to draft when payment_requires_internet", async () => {
     axios.mockImplementation(() =>
       Promise.resolve({
         status: 200,
@@ -2588,7 +2628,6 @@ describe("<Status /> interactions", () => {
     props = createTestProps();
     props.settings.payment_requires_internet = true;
     props.captivePortalSyncAuth = true;
-    props.settings.captive_portal_supports_coa = true;
     wrapper = shallow(<Status {...props} />, {
       context: {setLoading: jest.fn()},
       disableLifecycleMethods: true,
@@ -2604,7 +2643,6 @@ describe("<Status /> interactions", () => {
     // Route through draft to enforce portal login before gateway payment
     expect(props.navigate).toHaveBeenCalledWith("/default/payment/draft");
     expect(props.navigate).not.toHaveBeenCalledWith("/default/payment/process");
-    expect(localStorage.getItem("default_mustLogin")).toBe("true");
   });
   it("should hide limit-info element if getUserRadiusUsage fails", async () => {
     validateToken.mockReturnValue(true);

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -633,6 +633,79 @@ describe("<Status /> interactions", () => {
     jest.useRealTimers();
   });
 
+  it("authMessage planExhausted: false skips setPlanExhausted", async () => {
+    props = createTestProps();
+    const setLoadingMock = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: setLoadingMock},
+      disableLifecycleMethods: true,
+    });
+    jest.spyOn(toast, "info");
+    const status = wrapper.instance();
+    status.handlePostMessage({
+      data: {
+        message: "Informative message",
+        type: "authMessage",
+        planExhausted: false,
+      },
+      origin: "http://localhost",
+    });
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(props.setPlanExhausted).toHaveBeenCalledTimes(0);
+    expect(status.state.warningMessage).toBe("USAGE_LIMIT_EXHAUSTED_TXT");
+    expect(setLoadingMock).toHaveBeenCalledTimes(2);
+    expect(setLoadingMock).toHaveBeenLastCalledWith(false);
+  });
+
+  it("authMessage planExhausted: true calls setPlanExhausted", async () => {
+    props = createTestProps();
+    const setLoadingMock = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: setLoadingMock},
+      disableLifecycleMethods: true,
+    });
+    jest.spyOn(toast, "info");
+    const status = wrapper.instance();
+    status.handlePostMessage({
+      data: {
+        message: "PLAN_EXHAUSTED_TOAST",
+        type: "authMessage",
+        warningMessage: "USAGE_LIMIT_EXHAUSTED_TXT",
+        planExhausted: true,
+      },
+      origin: "http://localhost",
+    });
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(props.setPlanExhausted).toHaveBeenCalledTimes(1);
+    expect(status.state.warningMessage).toBe("USAGE_LIMIT_EXHAUSTED_TXT");
+    expect(setLoadingMock).toHaveBeenCalledTimes(2);
+    expect(setLoadingMock).toHaveBeenLastCalledWith(false);
+  });
+
+  it("authMessage without planExhausted defaults to true", async () => {
+    props = createTestProps();
+    const setLoadingMock = jest.fn();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: setLoadingMock},
+      disableLifecycleMethods: true,
+    });
+    jest.spyOn(toast, "info");
+    const status = wrapper.instance();
+    status.handlePostMessage({
+      data: {
+        message: "PLAN_EXHAUSTED_TOAST",
+        type: "authMessage",
+        warningMessage: "USAGE_LIMIT_EXHAUSTED_TXT",
+      },
+      origin: "http://localhost",
+    });
+    expect(toast.info).toHaveBeenCalledTimes(1);
+    expect(props.setPlanExhausted).toHaveBeenCalledTimes(1);
+    expect(status.state.warningMessage).toBe("USAGE_LIMIT_EXHAUSTED_TXT");
+    expect(setLoadingMock).toHaveBeenCalledTimes(2);
+    expect(setLoadingMock).toHaveBeenLastCalledWith(false);
+  });
+
   it("test handlePostMessage internet-mode", async () => {
     props = createTestProps();
     const setLoadingMock = jest.fn();

--- a/client/components/status/status.test.js
+++ b/client/components/status/status.test.js
@@ -2324,6 +2324,33 @@ describe("<Status /> interactions", () => {
     await tick();
     expect(toast.error.mock.calls.length).toBe(1);
   });
+  it("test upgradeUserPlan stores in_upgrade", async () => {
+    axios.mockImplementation(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        data: {
+          payment_url: "https://payment.example.com/pay/1",
+          in_upgrade: true,
+        },
+      }),
+    );
+    props = createTestProps();
+    wrapper = shallow(<Status {...props} />, {
+      context: {setLoading: jest.fn()},
+      disableLifecycleMethods: true,
+    });
+    wrapper.setState({upgradePlans: [{id: "1"}]});
+    wrapper.instance().upgradeUserPlan({target: {value: 0}});
+    await tick();
+    expect(props.setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_url: "https://payment.example.com/pay/1",
+        in_upgrade: true,
+      }),
+    );
+    expect(props.navigate).toHaveBeenCalledWith("/default/payment/process");
+  });
   it("should hide limit-info element if getUserRadiusUsage fails", async () => {
     validateToken.mockReturnValue(true);
     axios.mockImplementation(() =>

--- a/client/constants/index.js
+++ b/client/constants/index.js
@@ -24,5 +24,6 @@ export const updateMethodApiUrl = (orgSlug) =>
   `${prefix}/${orgSlug}/account/registration-method/`;
 export const plansApiUrl = `${prefix}/{orgSlug}/plan/`;
 export const upgradePlanApiUrl = `${prefix}/{orgSlug}/plan/upgrade`;
+export const cancelUpgradePlanApiUrl = `${prefix}/{orgSlug}/plan/cancel`;
 export const modalContentUrl = (orgSlug) => `${prefix}/${orgSlug}/modal`;
 export const mainToastId = "main_toast_id";

--- a/client/reducers/organization.js
+++ b/client/reducers/organization.js
@@ -26,6 +26,7 @@ export const initialState = {
     auth_token: undefined,
     radius_user_token: undefined,
     payment_url: undefined,
+    in_upgrade: undefined,
   },
   settings: {
     mobile_phone_verification: undefined,

--- a/client/test-translation.json
+++ b/client/test-translation.json
@@ -257,6 +257,10 @@
         "msgid": "PAY_GIVE_UP_BTN",
         "msgstr": ["Cancel operation and log out"]
       },
+      "PAY_GO_BACK_BTN": {
+        "msgid": "PAY_GO_BACK_BTN",
+        "msgstr": ["Cancel operation and go back to your account"]
+      },
       "PWD_RESET_TITL": {
         "msgid": "PWD_RESET_TITL",
         "msgstr": ["Reset Password"]

--- a/client/utils/cancel-upgrade-plan.js
+++ b/client/utils/cancel-upgrade-plan.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+import {cancelUpgradePlanApiUrl} from "../constants";
+import getLanguageHeaders from "./get-language-headers";
+
+const cancelUpgradePlan = (orgSlug, authToken, language) =>
+  axios({
+    method: "post",
+    headers: {
+      "content-type": "application/json",
+      "accept-language": getLanguageHeaders(language),
+      Authorization: `Bearer ${authToken}`,
+    },
+    url: cancelUpgradePlanApiUrl.replace("{orgSlug}", orgSlug),
+  }).then((response) => response.data);
+
+export default cancelUpgradePlan;

--- a/client/utils/synced-storage.js
+++ b/client/utils/synced-storage.js
@@ -60,7 +60,8 @@ export const resolveStoredValue = (
 
 /**
  * Removes a value previously persisted via storeValue from both
- * cookies and localStorage.
+ * cookies and localStorage. Unlike storeValue/resolveStoredValue, this
+ * runs unconditionally: clearing is safe even if sync auth is off.
  *
  * @param {string} key - The key to remove.
  * @param {Cookies} cookies - The cookies instance used to remove the cookie.

--- a/client/utils/synced-storage.js
+++ b/client/utils/synced-storage.js
@@ -1,0 +1,71 @@
+import {localStorage} from "./storage";
+
+/**
+ * Stores a value in both cookies and localStorage if synchronous
+ * captive portal authentication is enabled.
+ *
+ * In synchronous authentication, submitting the captive portal form
+ * triggers a page reload, which resets the component state.
+ * Storing the value in cookies ensures it persists across reloads.
+ *
+ * The value is also saved in localStorage as a fallback in case the browser does not support cookies.
+ *
+ * @param {boolean} captivePortalSyncAuth - Whether synchronous authentication is enabled.
+ * @param {string} key - The key under which the value is stored.
+ * @param {boolean} value - The value to store.
+ * @param {Cookies} cookies - The cookies instance used to set the cookie.
+ */
+export const storeValue = (captivePortalSyncAuth, key, value, cookies) => {
+  if (!captivePortalSyncAuth) {
+    return;
+  }
+  localStorage.setItem(key, value);
+  cookies.set(key, value, {path: "/", maxAge: 60});
+};
+
+/**
+ * Resolves the correct value by checking cookies, then localStorage,
+ * falling back to a default value if neither is found.
+ *
+ * @param {boolean} captivePortalSyncAuth - Whether synchronization is enabled.
+ * @param {string} key - The key to look for in cookies and localStorage.
+ * @param {*} fallback - The fallback value if no valid stored value is found.
+ * @param {Cookies} cookies - The cookies instance used to read the cookie.
+ * @returns {*} - The selected value based on storage or fallback.
+ */
+export const resolveStoredValue = (
+  captivePortalSyncAuth,
+  key,
+  fallback,
+  cookies,
+) => {
+  if (!captivePortalSyncAuth) {
+    return fallback;
+  }
+
+  const cookieValue = cookies.get(key);
+  if (cookieValue !== undefined) {
+    localStorage.removeItem(key);
+    return cookieValue;
+  }
+
+  const localStorageValue = localStorage.getItem(key);
+  if (localStorageValue !== null) {
+    localStorage.removeItem(key);
+    return localStorageValue === "true";
+  }
+
+  return fallback;
+};
+
+/**
+ * Removes a value previously persisted via storeValue from both
+ * cookies and localStorage.
+ *
+ * @param {string} key - The key to remove.
+ * @param {Cookies} cookies - The cookies instance used to remove the cookie.
+ */
+export const clearStoredValue = (key, cookies) => {
+  localStorage.removeItem(key);
+  cookies.remove(key, {path: "/"});
+};

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -32,6 +32,11 @@ import updateRegistrationMethod from "./update-registration-method";
 import getPlans from "./get-plans";
 import upgradePlan from "./upgrade-plan";
 import cancelUpgradePlan from "./cancel-upgrade-plan";
+import {
+  storeValue,
+  resolveStoredValue,
+  clearStoredValue,
+} from "./synced-storage";
 import {cancelUpgradePlanApiUrl, upgradePlanApiUrl} from "../constants";
 
 jest.mock("axios");
@@ -778,6 +783,69 @@ describe("storage tests", () => {
     storageMock.setItem("organization", "openwisp");
     storageMock.clear();
     expect(storageMock.getItem("organization")).toEqual(undefined);
+  });
+});
+describe("synced-storage tests", () => {
+  afterEach(() => {
+    localStorage.clear();
+    new Cookies().remove("test_key", {path: "/"});
+  });
+
+  it("storeValue should do nothing if sync auth is disabled", () => {
+    const cookies = new Cookies();
+    storeValue(false, "test_key", "true", cookies);
+    expect(cookies.get("test_key")).toBeUndefined();
+    expect(localStorage.getItem("test_key")).toEqual(null);
+  });
+
+  it("storeValue should persist to cookies and localStorage if sync auth is enabled", () => {
+    const cookies = new Cookies();
+    storeValue(true, "test_key", "true", cookies);
+    expect(cookies.get("test_key")).toEqual(true);
+    expect(localStorage.getItem("test_key")).toEqual("true");
+  });
+
+  it("resolveStoredValue should return the fallback if sync auth is disabled", () => {
+    const cookies = new Cookies();
+    cookies.set("test_key", "true", {path: "/", maxAge: 60});
+    expect(resolveStoredValue(false, "test_key", "fallback", cookies)).toEqual(
+      "fallback",
+    );
+  });
+
+  it("resolveStoredValue should read from cookies and clear localStorage", () => {
+    const cookies = new Cookies();
+    cookies.set("test_key", "true", {path: "/", maxAge: 60});
+    localStorage.setItem("test_key", "true");
+    expect(resolveStoredValue(true, "test_key", undefined, cookies)).toEqual(
+      true,
+    );
+    expect(localStorage.getItem("test_key")).toEqual(null);
+  });
+
+  it("resolveStoredValue should fall back to localStorage if cookies are unavailable", () => {
+    const cookies = new Cookies();
+    localStorage.setItem("test_key", "true");
+    expect(resolveStoredValue(true, "test_key", undefined, cookies)).toEqual(
+      true,
+    );
+    expect(localStorage.getItem("test_key")).toEqual(null);
+  });
+
+  it("resolveStoredValue should return the fallback if nothing is stored", () => {
+    const cookies = new Cookies();
+    expect(resolveStoredValue(true, "test_key", "fallback", cookies)).toEqual(
+      "fallback",
+    );
+  });
+
+  it("clearStoredValue should remove the value from cookies and localStorage", () => {
+    const cookies = new Cookies();
+    cookies.set("test_key", "true", {path: "/", maxAge: 60});
+    localStorage.setItem("test_key", "true");
+    clearStoredValue("test_key", cookies);
+    expect(cookies.get("test_key")).toBeUndefined();
+    expect(localStorage.getItem("test_key")).toEqual(null);
   });
 });
 describe("getPaymentStatusRedirectUrl tests", () => {

--- a/client/utils/utils.test.js
+++ b/client/utils/utils.test.js
@@ -31,7 +31,8 @@ import withRouteProps from "./with-route-props";
 import updateRegistrationMethod from "./update-registration-method";
 import getPlans from "./get-plans";
 import upgradePlan from "./upgrade-plan";
-import {upgradePlanApiUrl} from "../constants";
+import cancelUpgradePlan from "./cancel-upgrade-plan";
+import {cancelUpgradePlanApiUrl, upgradePlanApiUrl} from "../constants";
 
 jest.mock("axios");
 jest.mock("./load-translation");
@@ -262,6 +263,48 @@ describe("Validate Token tests", () => {
     expect(axios.mock.calls.length).toBe(0);
     expect(result).toBe(true);
     expect(setUserData.mock.calls.length).toBe(0);
+    expect(logout.mock.calls.length).toBe(0);
+  });
+  it("should make api call if user is upgrading and payment_url is missing", async () => {
+    axios.mockImplementationOnce(() =>
+      Promise.resolve({
+        status: 200,
+        statusText: "OK",
+        data: {
+          response_code: "AUTH_TOKEN_VALIDATION_SUCCESSFUL",
+          radius_user_token: "o6AQLY0aQjD3yuihRKLknTn8krcQwuy2Av6MCsFB",
+          username: "tester@tester.com",
+          is_active: true,
+          is_verified: true,
+          method: "mobile_phone",
+          in_upgrade: true,
+          payment_url: "https://payment.example.com/pay/2",
+        },
+      }),
+    );
+    const {orgSlug, cookies, setUserData, userData, logout, language} =
+      getArgs();
+    cookies.set(`${orgSlug}_auth_token`, "token");
+    userData.radius_user_token = "token";
+    userData.method = "mobile_phone";
+    userData.is_verified = true;
+    userData.in_upgrade = true;
+    userData.payment_url = null;
+    const result = await validateToken(
+      cookies,
+      orgSlug,
+      setUserData,
+      userData,
+      logout,
+      language,
+    );
+    expect(axios).toHaveBeenCalled();
+    expect(result).toBe(true);
+    expect(setUserData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payment_url: "https://payment.example.com/pay/2",
+      }),
+    );
     expect(logout.mock.calls.length).toBe(0);
   });
   it("should make api call if radius token is present but password_expired is true", async () => {
@@ -1035,5 +1078,32 @@ describe("upgrade-plan", () => {
     await expect(
       upgradePlan("default", "premium", "test-token", "en"),
     ).rejects.toBe(error);
+  });
+});
+
+describe("cancel-upgrade-plan", () => {
+  it("makes POST request with correct URL and headers", async () => {
+    const mockResponse = {in_upgrade: false, payment_url: null};
+    axios.mockResolvedValueOnce({data: mockResponse});
+    const result = await cancelUpgradePlan("default", "test-token", "en");
+    expect(axios).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "post",
+        headers: expect.objectContaining({
+          "content-type": "application/json",
+          Authorization: "Bearer test-token",
+        }),
+        url: cancelUpgradePlanApiUrl.replace("{orgSlug}", "default"),
+      }),
+    );
+    expect(result).toBe(mockResponse);
+  });
+
+  it("rejects on request failure", async () => {
+    const error = new Error("request failed");
+    axios.mockRejectedValueOnce(error);
+    await expect(cancelUpgradePlan("default", "test-token", "en")).rejects.toBe(
+      error,
+    );
   });
 });

--- a/client/utils/validate-token.js
+++ b/client/utils/validate-token.js
@@ -29,7 +29,8 @@ const validateToken = async (
         userData.password_expired === true)) ||
       (userData.method === "bank_card" &&
         userData.is_verified !== true &&
-        !userData.payment_url))
+        !userData.payment_url) ||
+      (userData.in_upgrade === true && !userData.payment_url))
   ) {
     try {
       const response = await axios({

--- a/docs/user/settings.rst
+++ b/docs/user/settings.rst
@@ -124,6 +124,18 @@ browsers may fail to detect successful login when this method is used.
 Set ``captive_portal_sync_auth`` to ``true`` to submit the login form
 synchronously and trigger a full page reload upon authentication:
 
+``captive_portal_supports_coa``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- **Type**: ``boolean``
+- **Default**: ``false``
+
+Set this option to ``true`` when your captive portal supports RADIUS
+Change of Authorization (CoA). After a successful payment, OpenWISP
+updates the session's RadiusGroup, and the captive portal applies the new
+plan's limits automatically. This avoids the logout/login cycle that WiFi
+Login Pages would otherwise require.
+
 Status Page Settings
 --------------------
 

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -446,6 +446,11 @@ msgstr ""
 "Wenn ihre Transaktion nicht erfolgreich war, wenden Sie sich bitte an den "
 "Support an"
 
+#.  failed payment case
+#: client/components/payment-status/payment-status.js:230
+msgid "PAY_GO_BACK_BTN"
+msgstr "Vorgang abbrechen und zu Ihrem Konto zurückkehren"
+
 #: client/components/password-reset/password-reset.js:32
 msgid "PWD_RESET_TITL"
 msgstr "Passwort zurücksetzen"

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -445,6 +445,11 @@ msgstr ""
 "If you cannot complete the transaction you can either try to get in touch "
 "with your bank or cancel the operation."
 
+#.  failed payment case
+#: client/components/payment-status/payment-status.js:230
+msgid "PAY_GO_BACK_BTN"
+msgstr "Cancel operation and go back to your account"
+
 #: client/components/password-reset/password-reset.js:32
 msgid "PWD_RESET_TITL"
 msgstr "Reset Password"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -451,6 +451,11 @@ msgstr ""
 "Si no puede completar la transacción puede intentar ponerse en contacto con "
 "su banco o cancelar la operación."
 
+#.  failed payment case
+#: client/components/payment-status/payment-status.js:230
+msgid "PAY_GO_BACK_BTN"
+msgstr "Cancelar operación y volver a tu cuenta"
+
 #: client/components/password-reset/password-reset.js:32
 msgid "PWD_RESET_TITL"
 msgstr "Restablecer contraseña"

--- a/i18n/fur.po
+++ b/i18n/fur.po
@@ -446,6 +446,11 @@ msgstr ""
 "Se non riesci a completare la transazione puoi provare a metterti in "
 "contatto con la tua banca o annullare l'operazione."
 
+#.  failed payment case
+#: client/components/payment-status/payment-status.js:230
+msgid "PAY_GO_BACK_BTN"
+msgstr "Anule e torne al to account"
+
 #: client/components/password-reset/password-reset.js:32
 msgid "PWD_RESET_TITL"
 msgstr "Torne a impuestâ la password"

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -447,6 +447,11 @@ msgstr ""
 "Se non riesci a completare la transazione puoi provare a metterti in "
 "contatto con la tua banca o annullare l'operazione."
 
+#.  failed payment case
+#: client/components/payment-status/payment-status.js:230
+msgid "PAY_GO_BACK_BTN"
+msgstr "Annulla e torna al tuo account"
+
 #: client/components/password-reset/password-reset.js:32
 msgid "PWD_RESET_TITL"
 msgstr "Reimposta password"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -450,6 +450,11 @@ msgstr "Попробуйте снова"
 msgid "PAY_GIVE_UP_TXT"
 msgstr "В случае возникновения проблем обращайтесь в сервис"
 
+#.  failed payment case
+#: client/components/payment-status/payment-status.js:230
+msgid "PAY_GO_BACK_BTN"
+msgstr "Отменить и вернуться в личный кабинет"
+
 #: client/components/password-reset/password-reset.js:32
 msgid "PWD_RESET_TITL"
 msgstr "Изменить пароль"

--- a/i18n/sl.po
+++ b/i18n/sl.po
@@ -432,6 +432,11 @@ msgid "PAY_GIVE_UP_TXT"
 msgstr ""
 "Če transakcija ni bila uspešna, se obrite na službo za podporo uporabnikom."
 
+#.  failed payment case
+#: client/components/payment-status/payment-status.js:230
+msgid "PAY_GO_BACK_BTN"
+msgstr "Preklic in vrnitev na račun"
+
 #: client/components/password-reset/password-reset.js:32
 msgid "PWD_RESET_TITL"
 msgstr "Ponastavite geslo"

--- a/internals/config/default.yml
+++ b/internals/config/default.yml
@@ -8,6 +8,7 @@ settings:
   subscriptions: false
   payment_iframe: false
   payment_requires_internet: false
+  captive_portal_supports_coa: false
   passwordless_auth_token_name: "sesame"
 
 # configuration variables for the server app

--- a/organizations/default/default.yml
+++ b/organizations/default/default.yml
@@ -5,6 +5,7 @@ slug: "default"
 settings:
   mobile_phone_verification: false
   subscriptions: false
+  captive_portal_supports_coa: false
 
 # configuration variables for the server app
 server:

--- a/server/controllers/user-cancel-upgrade-plan-controller.js
+++ b/server/controllers/user-cancel-upgrade-plan-controller.js
@@ -1,0 +1,63 @@
+import axios from "axios";
+import merge from "deepmerge";
+import config from "../config.json";
+import defaultConfig from "../utils/default-config";
+import {logResponseError} from "../utils/logger";
+import reverse from "../utils/openwisp-urls";
+import getSlug from "../utils/get-slug";
+
+const userCancelUpgradePlan = (req, res) => {
+  const reqOrg = req.params.organization;
+  const validSlug = config.some((org) => {
+    if (org.slug === reqOrg) {
+      // merge default config and custom config
+      const conf = merge(defaultConfig, org);
+      const {host} = conf;
+      const userUpgradePlanUrl = reverse(
+        "user_plan_radius_usage",
+        getSlug(conf),
+      );
+      const timeout = conf.timeout * 1000;
+      // make AJAX request
+      axios({
+        method: "post",
+        headers: {
+          "content-type": "application/json",
+          Authorization: req.headers.authorization,
+          "accept-language": req.headers["accept-language"],
+        },
+        url: `${host}${userUpgradePlanUrl}/cancel/`,
+        timeout,
+      })
+        .then((response) => {
+          res
+            .status(response.status)
+            .type("application/json")
+            .send(response.data);
+        })
+        .catch((error) => {
+          logResponseError(error);
+          // forward error
+          try {
+            res
+              .status(error.response.status)
+              .type("application/json")
+              .send(error.response.data);
+          } catch (err) {
+            res.status(500).type("application/json").send({
+              response_code: "INTERNAL_SERVER_ERROR",
+            });
+          }
+        });
+    }
+    return org.slug === reqOrg;
+  });
+  // return 404 for invalid organization slug or org not listed in config
+  if (!validSlug) {
+    res.status(404).type("application/json").send({
+      response_code: "NOT_FOUND",
+    });
+  }
+};
+
+export default userCancelUpgradePlan;

--- a/server/controllers/user-cancel-upgrade-plan-controller.js
+++ b/server/controllers/user-cancel-upgrade-plan-controller.js
@@ -12,8 +12,8 @@ const userCancelUpgradePlan = (req, res) => {
     if (org.slug === reqOrg) {
       const conf = merge(defaultConfig, org);
       const {host} = conf;
-      const userUpgradePlanUrl = reverse(
-        "user_plan_radius_usage",
+      const userUpgradeCancelUrl = reverse(
+        "user_plan_radius_usage_cancel",
         getSlug(conf),
       );
       const timeout = conf.timeout * 1000;
@@ -24,7 +24,7 @@ const userCancelUpgradePlan = (req, res) => {
           Authorization: req.headers.authorization,
           "accept-language": req.headers["accept-language"],
         },
-        url: `${host}${userUpgradePlanUrl}/cancel/`,
+        url: `${host}${userUpgradeCancelUrl}`,
         timeout,
       })
         .then((response) => {

--- a/server/controllers/user-cancel-upgrade-plan-controller.js
+++ b/server/controllers/user-cancel-upgrade-plan-controller.js
@@ -10,7 +10,6 @@ const userCancelUpgradePlan = (req, res) => {
   const reqOrg = req.params.organization;
   const validSlug = config.some((org) => {
     if (org.slug === reqOrg) {
-      // merge default config and custom config
       const conf = merge(defaultConfig, org);
       const {host} = conf;
       const userUpgradePlanUrl = reverse(
@@ -18,7 +17,6 @@ const userCancelUpgradePlan = (req, res) => {
         getSlug(conf),
       );
       const timeout = conf.timeout * 1000;
-      // make AJAX request
       axios({
         method: "post",
         headers: {
@@ -37,7 +35,6 @@ const userCancelUpgradePlan = (req, res) => {
         })
         .catch((error) => {
           logResponseError(error);
-          // forward error
           try {
             res
               .status(error.response.status)
@@ -52,7 +49,6 @@ const userCancelUpgradePlan = (req, res) => {
     }
     return org.slug === reqOrg;
   });
-  // return 404 for invalid organization slug or org not listed in config
   if (!validSlug) {
     res.status(404).type("application/json").send({
       response_code: "NOT_FOUND",

--- a/server/controllers/user-cancel-upgrade-plan-controller.test.js
+++ b/server/controllers/user-cancel-upgrade-plan-controller.test.js
@@ -1,0 +1,124 @@
+import axios from "axios";
+import userCancelUpgradePlan from "./user-cancel-upgrade-plan-controller";
+
+jest.mock("axios");
+jest.mock("../utils/logger", () => ({
+  logResponseError: jest.fn(),
+}));
+jest.mock("../config.json", () => [
+  {
+    slug: "default",
+    host: "https://radius.test",
+    timeout: 10,
+  },
+]);
+
+const createResponse = () => {
+  const res = {};
+  res.status = jest.fn(() => res);
+  res.type = jest.fn(() => res);
+  res.send = jest.fn(() => res);
+  return res;
+};
+
+describe("user-cancel-upgrade-plan-controller", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+    jest.restoreAllMocks();
+  });
+
+  it("proxies the upgrade plan cancellation", async () => {
+    axios.mockResolvedValueOnce({
+      status: 200,
+      data: {response_code: "PLAN_CANCELLED"},
+    });
+    const res = createResponse();
+    await userCancelUpgradePlan(
+      {
+        params: {organization: "default"},
+        headers: {
+          authorization: "Bearer test-token",
+          "accept-language": "en",
+        },
+      },
+      res,
+    );
+    expect(axios).toHaveBeenCalledWith({
+      method: "post",
+      headers: {
+        "content-type": "application/json",
+        Authorization: "Bearer test-token",
+        "accept-language": "en",
+      },
+      url: "https://radius.test/api/v1/subscriptions/organization/default/account/plan/cancel/",
+      timeout: 10000,
+    });
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.type).toHaveBeenCalledWith("application/json");
+    expect(res.send).toHaveBeenCalledWith({response_code: "PLAN_CANCELLED"});
+  });
+
+  it("returns 404 for an invalid organization slug", () => {
+    const res = createResponse();
+    userCancelUpgradePlan(
+      {
+        params: {organization: "missing-org"},
+        headers: {},
+      },
+      res,
+    );
+    expect(axios).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.type).toHaveBeenCalledWith("application/json");
+    expect(res.send).toHaveBeenCalledWith({
+      response_code: "NOT_FOUND",
+    });
+  });
+
+  it("forwards the upstream error status and data", async () => {
+    const error = new Error("Bad request");
+    error.response = {
+      status: 400,
+      data: {response_code: "BAD_REQUEST"},
+    };
+    axios.mockImplementationOnce(() => Promise.reject(error));
+    const res = createResponse();
+    await userCancelUpgradePlan(
+      {
+        params: {organization: "default"},
+        headers: {
+          authorization: "Bearer test-token",
+          "accept-language": "en",
+        },
+      },
+      res,
+    );
+    await Promise.resolve();
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.type).toHaveBeenCalledWith("application/json");
+    expect(res.send).toHaveBeenCalledWith({response_code: "BAD_REQUEST"});
+  });
+
+  it("handles error without error.response.status (internal error)", async () => {
+    const error = new Error("Internal server error");
+    axios.mockImplementationOnce(() => Promise.reject(error));
+    const res = createResponse();
+    await userCancelUpgradePlan(
+      {
+        params: {organization: "default"},
+        headers: {
+          authorization: "Bearer test-token",
+          "accept-language": "en",
+        },
+      },
+      res,
+    );
+    await Promise.resolve();
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.type).toHaveBeenCalledWith("application/json");
+    expect(res.send).toHaveBeenCalledWith({
+      response_code: "INTERNAL_SERVER_ERROR",
+    });
+  });
+});

--- a/server/routes/plans.js
+++ b/server/routes/plans.js
@@ -1,11 +1,13 @@
 import {Router} from "express";
 import plans from "../controllers/plans-controller";
 import userUpgradePlan from "../controllers/user-upgrade-plan-controller";
+import userCancelUpgradePlan from "../controllers/user-cancel-upgrade-plan-controller";
 import errorHandler from "../utils/error-handler";
 
 const router = Router({mergeParams: true});
 
 router.get("/", errorHandler(plans));
 router.post("/upgrade", errorHandler(userUpgradePlan));
+router.post("/cancel", errorHandler(userCancelUpgradePlan));
 
 export default router;

--- a/server/utils/openwisp-urls.js
+++ b/server/utils/openwisp-urls.js
@@ -9,6 +9,7 @@ const paths = {
   user_radius_sessions: "/account/session",
   user_radius_usage: "/account/usage",
   user_plan_radius_usage: "/account/plan",
+  user_plan_radius_usage_cancel: "/account/plan/cancel/",
   create_mobile_phone_token: "/account/phone/token",
   mobile_phone_token_status: "/account/phone/token/active",
   verify_mobile_phone_token: "/account/phone/verify",
@@ -27,7 +28,8 @@ const reverse = (name, orgSlug) => {
   if (
     name === "plans" ||
     name === "payment_status" ||
-    name === "user_plan_radius_usage"
+    name === "user_plan_radius_usage" ||
+    name === "user_plan_radius_usage_cancel"
   ) {
     prefix = prefix.replace("/radius/", "/subscriptions/");
   }


### PR DESCRIPTION


## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](http://openwisp.io/docs/developer/contributing.html).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

Closes #1145
Fixes #1147


## Description of Changes

A mobile_phone-registered, already-verified user whose plan-upgrade payment failed was silently redirected to /status instead of /payment/failed, because the redirect guards in PaymentStatus were written only for the bank_card registration flow and could not tell a mid-upgrade failure apart from an unrelated already-verified visit.

Read the new `in_upgrade` flag to recognize this case and let the user retry the payment or go back to their account without being logged out, since their existing plan stays active either way.



