### PR TITLE
[fix] Allow Social/SAML registered users to change password on expiration

### DIFF
--- a/client/components/password-change/password-change.js
+++ b/client/components/password-change/password-change.js
@@ -166,7 +166,11 @@ export default class PasswordChange extends React.Component {
     const {errors, newPassword1, newPassword2, hidePassword, currentPassword} =
       this.state;
     const toggler = () => this.setState({hidePassword: !hidePassword});
-    if (userData && ["saml", "social_login"].includes(userData.method))
+    if (
+      userData &&
+      ["saml", "social_login"].includes(userData.method) &&
+      userData.password_expired !== true
+    )
       return <Navigate to={`/${orgSlug}/status`} />;
     return (
       <div className="container content" id="password-change">

--- a/client/components/password-change/password-change.test.js
+++ b/client/components/password-change/password-change.test.js
@@ -260,4 +260,24 @@ describe("<PasswordChange /> interactions", () => {
     expect(wrapper.find("Navigate").length).toEqual(1);
     expect(wrapper.find("Navigate").props().to).toEqual("/default/status");
   });
+  it("should allow SAML / Social Login users to change password if password is expired", async () => {
+    props = createTestProps();
+    PasswordChange.contextTypes = {
+      setLoading: PropTypes.func,
+      getLoading: PropTypes.func,
+    };
+    props.userData.method = "saml";
+    props.userData.password_expired = true;
+    wrapper = await shallow(<PasswordChange {...props} />, {
+      context: {setLoading: jest.fn(), getLoading: jest.fn()},
+    });
+    expect(wrapper.find("Navigate").length).toEqual(0);
+    expect(wrapper.find("form").length).toEqual(1);
+    props.userData.method = "social_login";
+    wrapper = await shallow(<PasswordChange {...props} />, {
+      context: {setLoading: jest.fn(), getLoading: jest.fn()},
+    });
+    expect(wrapper.find("Navigate").length).toEqual(0);
+    expect(wrapper.find("form").length).toEqual(1);
+  });
 });


### PR DESCRIPTION



## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.

## Reference to Existing Issue

<!-- Please [open a new issue](https://github.com/openwisp/openwisp-wifi-login-pages/issues/new/choose) if there isn't an existing issue yet. -->

N/A

## Description of Changes

Allow users registered with Social Login or SAML to change their passowrd if their password has expired.

In typical user flow, a user registered with Social Login / SAML cannot set their password from WLP. But, a password for such a user can be set from the OpenWISP admin. Hence, this scenario is an outlier, but surely can happen in the wild. 

# Screenshot 

The following screen capture demonstrates the redirect loop which the user will encounter without this fix.  

[](https://github.com/user-attachments/assets/1a7e0ca6-d23e-4dd4-880f-d8ad7e0b1180)
