### PR TITLE
[fix] Fixed misleading password reset error messages

### DIFF
--- a/browser-test/password-confirm.test.js
+++ b/browser-test/password-confirm.test.js
@@ -20,7 +20,7 @@ describe("Selenium tests for <PasswordReset />", () => {
     await tearDown(driver);
   });
 
-  it("should show not found on password confirm", async () => {
+  it("should show invalid password reset URL error on password confirm", async () => {
     await driver.get(urls.passwordConfirm("uid", "token"));
     const data = initialData();
     const password = await getElementByCss(driver, "input#password");
@@ -34,6 +34,8 @@ describe("Selenium tests for <PasswordReset />", () => {
     submitBtn.click();
     const successToastDiv = await getElementByCss(driver, "div[role=alert]");
     await driver.wait(until.elementIsVisible(successToastDiv));
-    expect(await successToastDiv.getText()).toEqual("Not found.");
+    expect(await successToastDiv.getText()).toEqual(
+      "Invalid password reset URL",
+    );
   });
 });

--- a/client/components/password-confirm/password-confirm.js
+++ b/client/components/password-confirm/password-confirm.js
@@ -84,7 +84,7 @@ export default class PasswordConfirm extends React.Component {
         toast.success(response.data.detail);
       })
       .catch((error) => {
-        const {data} = error.response;
+        const data = error.response?.data ?? {};
         let errorText = data.detail;
         if (!errorText && (data.new_password1 || data.new_password2)) {
           errorText = data.new_password1
@@ -99,6 +99,7 @@ export default class PasswordConfirm extends React.Component {
           // user, so a generic message is shown instead of the raw one.
           errorText = t`INVALID_PWD_RESET_URL`;
         }
+        if (!errorText) errorText = t`ERR_OCCUR`;
         logError(error, errorText);
         toast.error(errorText);
         setLoading(false);

--- a/client/components/password-confirm/password-confirm.js
+++ b/client/components/password-confirm/password-confirm.js
@@ -11,7 +11,6 @@ import LoadingContext from "../../utils/loading-context";
 import PasswordToggleIcon from "../../utils/password-toggle";
 
 import {confirmApiUrl} from "../../constants";
-import getErrorText from "../../utils/get-error-text";
 import logError from "../../utils/log-error";
 import handleChange from "../../utils/handle-change";
 import getError from "../../utils/get-error";
@@ -85,9 +84,20 @@ export default class PasswordConfirm extends React.Component {
         toast.success(response.data.detail);
       })
       .catch((error) => {
-        let errorText = getErrorText(error);
-        if (!errorText && error.response.data.token[0]) {
-          errorText = `token: ${error.response.data.token[0]}`;
+        const {data} = error.response;
+        let errorText = data.detail;
+        if (!errorText && (data.new_password1 || data.new_password2)) {
+          errorText = data.new_password1
+            ? data.new_password1[0]
+            : data.new_password2[0];
+        } else if (
+          !errorText &&
+          (data.uid || data.token || data.non_field_errors)
+        ) {
+          // uid/token errors (including a malformed uid, which the backend
+          // reports under non_field_errors) are never actionable by the
+          // user, so a generic message is shown instead of the raw one.
+          errorText = t`INVALID_PWD_RESET_URL`;
         }
         logError(error, errorText);
         toast.error(errorText);

--- a/client/components/password-confirm/password-confirm.test.js
+++ b/client/components/password-confirm/password-confirm.test.js
@@ -125,12 +125,17 @@ describe("<PasswordConfirm /> interactions", () => {
   let props;
   let wrapper;
   let originalError;
+  let originalLog;
   let lastConsoleOutuput;
 
   beforeEach(() => {
     originalError = console.error;
+    originalLog = console.log;
     lastConsoleOutuput = null;
     console.error = (...args) => {
+      lastConsoleOutuput = args;
+    };
+    console.log = (...args) => {
       lastConsoleOutuput = args;
     };
     PasswordConfirm.contextTypes = {
@@ -145,6 +150,7 @@ describe("<PasswordConfirm /> interactions", () => {
 
   afterEach(() => {
     console.error = originalError;
+    console.log = originalLog;
   });
 
   it("should change state values when handleChange function is invoked", () => {

--- a/client/components/password-confirm/password-confirm.test.js
+++ b/client/components/password-confirm/password-confirm.test.js
@@ -130,8 +130,8 @@ describe("<PasswordConfirm /> interactions", () => {
   beforeEach(() => {
     originalError = console.error;
     lastConsoleOutuput = null;
-    console.error = (data) => {
-      lastConsoleOutuput = data;
+    console.error = (...args) => {
+      lastConsoleOutuput = args;
     };
     PasswordConfirm.contextTypes = {
       setLoading: PropTypes.func,
@@ -139,7 +139,7 @@ describe("<PasswordConfirm /> interactions", () => {
     };
     props = createTestProps();
     wrapper = shallow(<PasswordConfirm {...props} />, {
-      context: loadingContextValue,
+      context: {...loadingContextValue, setLoading: jest.fn()},
     });
   });
 
@@ -187,6 +187,14 @@ describe("<PasswordConfirm /> interactions", () => {
           },
         }),
       )
+      .mockImplementationOnce(() =>
+        Promise.reject({
+          response: {
+            data: {new_password2: ["This password is too common."]},
+          },
+        }),
+      )
+      .mockImplementationOnce(() => Promise.reject({message: "Network Error"}))
       .mockImplementationOnce(() => Promise.resolve({data: {detail: true}}));
     wrapper.setState({
       newPassword1: "wrong password",
@@ -221,7 +229,13 @@ describe("<PasswordConfirm /> interactions", () => {
             expect(wrapper.instance().state.errors.nonField).toEqual(
               getTranslationString("INVALID_PWD_RESET_URL"),
             );
-            expect(lastConsoleOutuput).not.toBe(null);
+            expect(lastConsoleOutuput).toEqual([
+              "Status",
+              undefined,
+              undefined,
+              ":",
+              getTranslationString("INVALID_PWD_RESET_URL"),
+            ]);
             expect(spyToastError.mock.calls.length).toBe(2);
             expect(spyToastSuccess.mock.calls.length).toBe(0);
             lastConsoleOutuput = null;
@@ -263,8 +277,43 @@ describe("<PasswordConfirm /> interactions", () => {
             expect(wrapper.instance().state.errors.nonField).toEqual(
               "This password is too common.",
             );
-            expect(lastConsoleOutuput).not.toBe(null);
+            expect(lastConsoleOutuput).toEqual([
+              "Status",
+              undefined,
+              undefined,
+              ":",
+              "This password is too common.",
+            ]);
             expect(spyToastError.mock.calls.length).toBe(5);
+            expect(spyToastSuccess.mock.calls.length).toBe(0);
+            lastConsoleOutuput = null;
+          }),
+      )
+      .then(() =>
+        wrapper
+          .instance()
+          .handleSubmit({preventDefault: () => {}})
+          .then(() => {
+            expect(wrapper.instance().state.errors.nonField).toEqual(
+              "This password is too common.",
+            );
+            expect(lastConsoleOutuput).not.toBe(null);
+            expect(spyToastError.mock.calls.length).toBe(6);
+            expect(spyToastSuccess.mock.calls.length).toBe(0);
+            lastConsoleOutuput = null;
+          }),
+      )
+      .then(() =>
+        wrapper
+          .instance()
+          .handleSubmit({preventDefault: () => {}})
+          .then(() => {
+            const {setLoading} = wrapper.instance().context;
+            expect(wrapper.instance().state.errors.nonField).toEqual(
+              getTranslationString("ERR_OCCUR"),
+            );
+            expect(setLoading).toHaveBeenLastCalledWith(false);
+            expect(spyToastError.mock.calls.length).toBe(7);
             expect(spyToastSuccess.mock.calls.length).toBe(0);
             lastConsoleOutuput = null;
           }),
@@ -279,7 +328,7 @@ describe("<PasswordConfirm /> interactions", () => {
             expect(wrapper.find(".input.error")).toHaveLength(0);
             expect(wrapper.find(".success")).toHaveLength(1);
             expect(lastConsoleOutuput).toBe(null);
-            expect(spyToastError.mock.calls.length).toBe(5);
+            expect(spyToastError.mock.calls.length).toBe(7);
             expect(spyToastSuccess.mock.calls.length).toBe(1);
             lastConsoleOutuput = null;
           }),

--- a/client/components/password-confirm/password-confirm.test.js
+++ b/client/components/password-confirm/password-confirm.test.js
@@ -165,12 +165,26 @@ describe("<PasswordConfirm /> interactions", () => {
       )
       .mockImplementationOnce(() =>
         Promise.reject({
-          response: {data: {non_field_errors: ["non field errors"]}},
+          response: {
+            data: {non_field_errors: ["“uid” is not a valid UUID."]},
+          },
         }),
       )
       .mockImplementationOnce(() =>
         Promise.reject({
-          response: {data: {token: ["Invalid token"]}},
+          response: {data: {token: ["Invalid value"]}},
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.reject({
+          response: {data: {uid: ["Invalid value"]}},
+        }),
+      )
+      .mockImplementationOnce(() =>
+        Promise.reject({
+          response: {
+            data: {new_password1: ["This password is too common."]},
+          },
         }),
       )
       .mockImplementationOnce(() => Promise.resolve({data: {detail: true}}));
@@ -205,7 +219,7 @@ describe("<PasswordConfirm /> interactions", () => {
           .handleSubmit({preventDefault: () => {}})
           .then(() => {
             expect(wrapper.instance().state.errors.nonField).toEqual(
-              "non field errors",
+              getTranslationString("INVALID_PWD_RESET_URL"),
             );
             expect(lastConsoleOutuput).not.toBe(null);
             expect(spyToastError.mock.calls.length).toBe(2);
@@ -219,10 +233,38 @@ describe("<PasswordConfirm /> interactions", () => {
           .handleSubmit({preventDefault: () => {}})
           .then(() => {
             expect(wrapper.instance().state.errors.nonField).toEqual(
-              "token: Invalid token",
+              getTranslationString("INVALID_PWD_RESET_URL"),
             );
             expect(lastConsoleOutuput).not.toBe(null);
             expect(spyToastError.mock.calls.length).toBe(3);
+            expect(spyToastSuccess.mock.calls.length).toBe(0);
+            lastConsoleOutuput = null;
+          }),
+      )
+      .then(() =>
+        wrapper
+          .instance()
+          .handleSubmit({preventDefault: () => {}})
+          .then(() => {
+            expect(wrapper.instance().state.errors.nonField).toEqual(
+              getTranslationString("INVALID_PWD_RESET_URL"),
+            );
+            expect(lastConsoleOutuput).not.toBe(null);
+            expect(spyToastError.mock.calls.length).toBe(4);
+            expect(spyToastSuccess.mock.calls.length).toBe(0);
+            lastConsoleOutuput = null;
+          }),
+      )
+      .then(() =>
+        wrapper
+          .instance()
+          .handleSubmit({preventDefault: () => {}})
+          .then(() => {
+            expect(wrapper.instance().state.errors.nonField).toEqual(
+              "This password is too common.",
+            );
+            expect(lastConsoleOutuput).not.toBe(null);
+            expect(spyToastError.mock.calls.length).toBe(5);
             expect(spyToastSuccess.mock.calls.length).toBe(0);
             lastConsoleOutuput = null;
           }),
@@ -237,7 +279,7 @@ describe("<PasswordConfirm /> interactions", () => {
             expect(wrapper.find(".input.error")).toHaveLength(0);
             expect(wrapper.find(".success")).toHaveLength(1);
             expect(lastConsoleOutuput).toBe(null);
-            expect(spyToastError.mock.calls.length).toBe(3);
+            expect(spyToastError.mock.calls.length).toBe(5);
             expect(spyToastSuccess.mock.calls.length).toBe(1);
             lastConsoleOutuput = null;
           }),

--- a/client/test-translation.json
+++ b/client/test-translation.json
@@ -295,7 +295,7 @@
       },
       "INVALID_PWD_RESET_URL": {
         "msgid": "INVALID_PWD_RESET_URL",
-        "msgstr": ["Invalid password reset URL."]
+        "msgstr": ["Invalid password reset URL"]
       },
       "CONFIRM_PWD_LBL": {
         "msgid": "CONFIRM_PWD_LBL",

--- a/client/test-translation.json
+++ b/client/test-translation.json
@@ -293,6 +293,10 @@
         "msgid": "PWD_CONFIRM_ADD_TXT",
         "msgstr": ["Please enter your new password below."]
       },
+      "INVALID_PWD_RESET_URL": {
+        "msgid": "INVALID_PWD_RESET_URL",
+        "msgstr": ["Invalid password reset URL."]
+      },
       "CONFIRM_PWD_LBL": {
         "msgid": "CONFIRM_PWD_LBL",
         "msgstr": ["Confirm password"]

--- a/i18n/de.po
+++ b/i18n/de.po
@@ -504,6 +504,10 @@ msgstr "Passwort zurücksetzen"
 msgid "PWD_CONFIRM_ADD_TXT"
 msgstr "Bitte geben Sie Ihr neues Passwort nachfolgend ein"
 
+#: client/components/password-confirm/password-confirm.js:91
+msgid "INVALID_PWD_RESET_URL"
+msgstr "Ungültige URL zum Zurücksetzen des Passworts"
+
 #: client/components/password-confirm/password-confirm.js:205
 msgid "PWD_CONFIRM"
 msgstr "Bestätigen Sie die Passwortänderung"

--- a/i18n/en.po
+++ b/i18n/en.po
@@ -498,6 +498,10 @@ msgstr "Reset your password"
 msgid "PWD_CONFIRM_ADD_TXT"
 msgstr "Please enter your new password below."
 
+#: client/components/password-confirm/password-confirm.js:91
+msgid "INVALID_PWD_RESET_URL"
+msgstr "Invalid password reset URL"
+
 #: client/components/password-confirm/password-confirm.js:205
 msgid "PWD_CONFIRM"
 msgstr "Change password"

--- a/i18n/es.po
+++ b/i18n/es.po
@@ -509,6 +509,10 @@ msgstr "Restablecer su contraseña"
 msgid "PWD_CONFIRM_ADD_TXT"
 msgstr "Por favor, introduzca su nueva contraseña a continuación."
 
+#: client/components/password-confirm/password-confirm.js:91
+msgid "INVALID_PWD_RESET_URL"
+msgstr "URL de restablecimiento de contraseña no válida"
+
 #: client/components/password-confirm/password-confirm.js:205
 msgid "PWD_CONFIRM"
 msgstr "Cambiar la contraseña"

--- a/i18n/fur.po
+++ b/i18n/fur.po
@@ -502,6 +502,10 @@ msgstr "Torne a impuestâ la password"
 msgid "PWD_CONFIRM_ADD_TXT"
 msgstr "Inserìs la password gnove achì."
 
+#: client/components/password-confirm/password-confirm.js:91
+msgid "INVALID_PWD_RESET_URL"
+msgstr "URL no valide par tornâ a impuestâ la password"
+
 #: client/components/password-confirm/password-confirm.js:205
 msgid "PWD_CONFIRM"
 msgstr "Conferme il cambi de password"

--- a/i18n/it.po
+++ b/i18n/it.po
@@ -505,6 +505,10 @@ msgstr "Reimposta password"
 msgid "PWD_CONFIRM_ADD_TXT"
 msgstr "Inserisci la nuova password di seguito."
 
+#: client/components/password-confirm/password-confirm.js:91
+msgid "INVALID_PWD_RESET_URL"
+msgstr "URL per reimpostare la password non valida"
+
 #: client/components/password-confirm/password-confirm.js:205
 msgid "PWD_CONFIRM"
 msgstr "Conferma cambio password"

--- a/i18n/ru.po
+++ b/i18n/ru.po
@@ -503,6 +503,10 @@ msgstr "Подтвердите пароль"
 msgid "PWD_CONFIRM_ADD_TXT"
 msgstr "Введите новый пароль ещё раз"
 
+#: client/components/password-confirm/password-confirm.js:91
+msgid "INVALID_PWD_RESET_URL"
+msgstr "Недействительный URL для сброса пароля"
+
 #: client/components/password-confirm/password-confirm.js:205
 msgid "PWD_CONFIRM"
 msgstr "Подтвердите смену пароля"

--- a/i18n/sl.po
+++ b/i18n/sl.po
@@ -489,6 +489,10 @@ msgstr "Ponastavite geslo"
 msgid "PWD_CONFIRM_ADD_TXT"
 msgstr "Vpišite novo geslos."
 
+#: client/components/password-confirm/password-confirm.js:91
+msgid "INVALID_PWD_RESET_URL"
+msgstr "Neveljaven URL za ponastavitev gesla"
+
 #: client/components/password-confirm/password-confirm.js:205
 msgid "PWD_CONFIRM"
 msgstr "Potrdite spremembo gesla"


### PR DESCRIPTION


## Checklist

<!-- Pull requests not following the rules will be closed without further inspection. -->
<!-- Replace `[ ]` with `N/A` if the requirement is not applicable. -->

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- [x] I have written new test cases for new code and/or updated existing tests for changes to existing code.
- N/A I have updated the documentation.


## Description of Changes

Users saw raw backend field errors (e.g. "token: Invalid value") that gave no actionable information, and weak/invalid password errors from the backend were silently dropped from the toast.

Invalid uid/token errors (including a malformed uid, which the backend reports under non_field_errors) now show a generic "Invalid password reset URL" message instead, while password validation errors from the backend are now shown to the user. The full error is still logged to the console for debugging.

