### PR TITLE
[docs] Moved architecture diagrams to developer documentation

### DIFF
--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -11,7 +11,7 @@ within the OpenWISP architecture.
     :align: center
     :alt: OpenWISP Architecture: WiFi Login Pages module
 
-    **OpenWISP Architecture: highlighted wifi login pages module**
+    **OpenWISP Architecture: highlighted WiFi Login Pages module**
 
 .. important::
 

--- a/docs/developer/installation.rst
+++ b/docs/developer/installation.rst
@@ -3,6 +3,23 @@ Developer Installation Instructions
 
 .. include:: ../partials/developer-docs.rst
 
+The following diagram illustrates the role of the WiFi Login Pages module
+within the OpenWISP architecture.
+
+.. figure:: ../images/architecture-v2-wifi-login-pages.png
+    :target: ../../_images/architecture-v2-wifi-login-pages.png
+    :align: center
+    :alt: OpenWISP Architecture: WiFi Login Pages module
+
+    **OpenWISP Architecture: highlighted wifi login pages module**
+
+.. important::
+
+    For an enhanced viewing experience, open the image above in a new
+    browser tab.
+
+    Refer to :doc:`/general/architecture` for more information.
+
 .. contents:: **Table of contents**:
     :depth: 1
     :local:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,23 +20,6 @@ Refer to :doc:`user/intro` for a complete overview of features.
 **Need a quick overview?** `Try the demo instance of OpenWISP WiFi Login
 Pages <https://wifi.openwisp.io/demo/login>`_!
 
-The following diagram illustrates the role of the WiFi Login Pages module
-within the OpenWISP architecture.
-
-.. figure:: images/architecture-v2-wifi-login-pages.png
-    :target: ../_images/architecture-v2-wifi-login-pages.png
-    :align: center
-    :alt: OpenWISP Architecture: WiFi Login Pages module
-
-    **OpenWISP Architecture: highlighted wifi login pages module**
-
-.. important::
-
-    For an enhanced viewing experience, open the image above in a new
-    browser tab.
-
-    Refer to :doc:`/general/architecture` for more information.
-
 .. toctree::
     :caption: WiFi Login Pages Usage Docs
     :maxdepth: 1


### PR DESCRIPTION
## Checklist

- [x] I have read the [OpenWISP Contributing Guidelines](https://openwisp.io/docs/dev/developer/contributing.html) and [OpenWISP Anti AI Spam Policy](https://openwisp.io/docs/dev/general/code-of-conduct.html#anti-ai-spam-policy).
- [x] I have manually tested the changes proposed in this pull request.
- N/A I have written new test cases for new code and/or updated existing tests for changes to existing code.
- [x] I have updated the documentation.

## Reference to Existing Issue

N/A

## Description of Changes

Moves the OpenWISP architecture callout from the module landing page to the first developer documentation page.

## Screenshot

N/A